### PR TITLE
QuickCheck-based soundness fuzzing harness

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -134,23 +134,43 @@ fixture.
 3. [DONE] Add the dual (true-`Q`) property. (Loop-free generator so the exact
    postcondition is always discharged by the solver; `Failed`/timeout treated
    as a skip, `Invalid` as a regression.)
-4. [TODO] Add procedure generation with random `writes` clauses. To give this
-   teeth against the framing bug class, generate procedures with `ensures
-   { true }` and *incomplete* `writes`, and build `Q` asserting the pre-state
-   is preserved: a correct `writes_are_declared` check rejects them (Invalid),
-   but removing the check lets the caller's WLP skip the havoc and "prove" the
-   false triple (Valid).
-5. [TODO] Shrinker tuning + a helper to emit a failing case as a `.cav`
-   fixture. (Failures currently print a readable sexp of the `cmd` plus `s0`,
-   `s1`, and `Q`; a `.cav` pretty-printer would let counterexamples drop
-   straight into `test/`.)
+4. [DONE] Add procedure generation with random `writes` clauses (`prop_framing`
+   in `test/fuzz/fuzz.ml`). A generated procedure `f` has `requires/ensures
+   { true }` and, per non-hidden pool variable, a role: not-written,
+   written-and-declared, or written-but-undeclared. A distinguished `hidden`
+   global is always written (`+kh`, so it definitely changes) and never
+   declared, guaranteeing an incomplete `writes`. `main` calls `f()` and
+   asserts `hidden = s0(hidden)`. A correct `writes_are_declared` check rejects
+   `f` (Invalid); drop the check and the caller's WLP skips the havoc and
+   "proves" the false triple (Valid). The interpreter confirms `hidden` really
+   changed, keeping it a genuine differential test.
+5. [DONE] `.cav` fixture emitter (`emit_cav` in `test/fuzz/fuzz.ml`). Every
+   failure prints the counterexample as surface-syntax Cavalry, round-tripped
+   through the real parser/verifier, so it drops straight into `test/`.
+   Shrinking is QCheck2's structural default (no custom shrinkers needed);
+   counterexamples minimize to a few lines -- e.g. the framing case shrinks to
+   essentially `verify_false_writes_undeclared.cav`. Note: the grammar has no
+   parenthesised-`logic_expr` rule, so assertions are emitted paren-free and
+   rely on operator precedence (fine for the left-nested `&&` of comparisons
+   the harness builds); only `arith_expr` sub-terms are parenthesised.
 
 ## Validation
 
-The harness was smoke-tested by reintroducing the pre-fix unsound loop rule
-(dropping the havoc in `Hoare.Wlp.cmd`'s `While` case): the primary property
-fails and shrinks to `while c > 0 do t := k; c := c - 1 end` with invariant
-`true` and a false postcondition -- essentially `verify_false_loop_unquantified.cav`.
-With the correct rule restored it passes across seeds. The trivial invariant
-`true` is deliberately over-represented in the invariant generator because it
-is the shape that exposes this whole class.
+Both properties with teeth were smoke-tested by reintroducing the exact bugs
+this branch fixed, confirming the harness catches them and shrinks to a minimal
+`.cav`:
+
+- **Loop rule**: dropping the havoc in `Hoare.Wlp.cmd`'s `While` case makes the
+  primary property fail and shrink to `while c > 0 do t := k; c := c - 1 end`
+  with invariant `true` and a false postcondition -- essentially
+  `verify_false_loop_unquantified.cav`. The trivial invariant `true` is
+  deliberately over-represented in the invariant generator because it is the
+  shape that exposes this whole class.
+- **Framing / writes**: disabling the `writes_are_declared` guard in
+  `Hoare.verify` makes `prop_framing` fail and shrink to
+  `procedure f () = ... writes { } x <- x + 1 end` with `{ ...x = 0... } f() { x = 0 }`
+  -- essentially `verify_false_writes_undeclared.cav`. The emitted `.cav` was
+  round-tripped through `cav verify`: Valid (bug reproduced) with the guard off,
+  Invalid with it on.
+
+With the correct code, all three properties pass across seeds.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,156 @@
+# PLAN: QuickCheck-based soundness harness
+
+## Goal
+
+Automatically find **soundness** bugs in `Hoare.verify` — cases where the
+verifier certifies a Hoare triple `{P} C {Q}` as `Valid` even though the
+program can, starting from a state satisfying `P`, terminate in a state
+violating `Q`.
+
+The oracle is the interpreter (`Ast.Runtime.exec`): it is an independent
+implementation of the language semantics and is the ground truth for concrete
+runs. This makes soundness testing a **differential test** between
+`Hoare.verify` (symbolic) and `Runtime.exec` (concrete).
+
+Both bugs fixed on this branch (unquantified loop rule; unenforced `writes`
+clause) have this exact signature: `verify = Valid` while `exec` reaches a
+state contradicting `Q`. The harness is designed to catch that whole class.
+
+## Key semantic facts to respect
+
+- **Partial correctness.** WLP is the weakest *liberal* precondition: if the
+  program terminates, `Q` holds. A soundness counterexample must therefore be a
+  **terminating** run. Bound the interpreter with fuel and *discard* (do not
+  fail) runs that exceed it — non-termination is not a counterexample.
+- **Preconditions are assertions, not initializers.** The interpreter needs
+  variables bound before use, and reading an unbound variable raises
+  (`Runtime.UnboundError`). The generator must produce a concrete initial
+  environment separately from `P`.
+- **Incompleteness is expected and is not a soundness bug.** A *true* triple
+  can verify as `Invalid` (e.g. nonlinear arithmetic Alt-Ergo cannot close).
+  Execution cannot witness `∀`-facts, so the harness targets soundness
+  (`Valid`-but-false), not completeness.
+
+## Primary strategy: constructed false triples
+
+Do not generate random `P`/`Q` and hope to hit the `Valid` branch (you would
+almost always get `Invalid`). Instead construct triples that are *definitely
+false* and assert the verifier never accepts them:
+
+1. Generate a random well-typed `Program.cmd` `C` and a concrete initial
+   environment `s0` (a binding for every variable `C` reads).
+2. Execute `C` on `s0` with fuel. If it diverges or raises, **skip**.
+   Otherwise obtain the final state `s1`.
+3. Build `P` = a formula pinning `s0` exactly (`x = 3 && y = 5 && ...`), so the
+   triple ranges over the single state `s0`.
+4. Build `Q` = a formula **false on `s1`** (negate an atom that holds at `s1`,
+   or assert `v = s1(v) + 1` for some variable `v`).
+5. Property: `verify {P} C {Q}` **must** be `Invalid`. A `Valid` result is a
+   minimized soundness bug.
+
+### Dual property (regression / incompleteness signal)
+
+With the same `C`, `s0`, `s1`, build `Q'` = a formula **true on `s1`**. Then
+`verify {P} C {Q'}` **should** be `Valid`. Failures here are not unsoundness
+but catch regressions and gross incompleteness on fully-concrete triples (all
+linear, so the solver should handle them). Keep this property but treat its
+failures as lower severity / allow an ignore-list.
+
+## Generators
+
+Use `qcheck` (structured, well-typed generation + shrinking) rather than
+AFL/`crowbar` byte fuzzing — we need programs that type-check and shrinking that
+minimizes counterexamples to a few lines.
+
+- **`cmd` generator**, recursive with a depth/size budget:
+  - leaves: `Assgn (x, int_expr)`, trailing `IntExpr`
+  - nodes: `Seq`, `If (bool_expr, c, c')`, small bounded `While (inv, b, c)`,
+    `Proc` calls into a small generated procedure pool
+  - bias toward `Assgn`/`Seq`; keep `While` shallow and rare so runs terminate
+    within fuel.
+- **Variable pool**: a small fixed set of names (e.g. `x y z i j`) so aliasing
+  and collisions actually occur.
+- **`int_expr` / `bool_expr` generators** over the pool, ints from a small
+  range (e.g. `-8..8`) so nonlinear terms do not dominate and the concrete runs
+  stay small. Respect the GADT int/bool split (guards are `bool expr`,
+  assignment RHS is `int expr`).
+- **Invariant generator** for `While`: generate `Logic.expr` over the pool. It
+  does not need to be a true invariant — the constructed-false-triple property
+  holds regardless.
+- **Procedures**: generate a handful with random `writes` clauses (including
+  deliberately incomplete ones) to exercise framing.
+
+Seed the qcheck corpus with the existing `.cav` fixtures where practical.
+
+## Interpreter changes required
+
+- Add a **fuel-bounded** exec entry point (max loop iterations / steps) that
+  returns `Terminated of state | OutOfFuel | Raised`. Reuse `Runtime.exec_cmd`;
+  thread a decreasing counter through the `While` case.
+- Expose the **final environment** (all variable bindings), not just the return
+  value, so `s1` can be read for building `Q`. Today `exec` returns only the
+  top-level `int`.
+
+## Shrinking
+
+Rely on qcheck's shrinkers for `cmd`, the environment, and the chosen `Q`.
+Target: a counterexample shrinks to a minimal program + state + postcondition,
+suitable to drop straight into `test/` as a `verify_false_*.cav` regression
+fixture.
+
+## Wiring
+
+- New test executable/library, e.g. `test/fuzz/` with `qcheck-core` (+
+  `qcheck-alcotest` or the inline-test integration).
+- Add `qcheck` to `cavalry.opam` dev/test deps and the test `dune`.
+- Run a **small** iteration count under `dune runtest` (fast CI), with an env
+  knob (e.g. `CAVALRY_FUZZ_COUNT`) to crank it up for longer local/nightly
+  sessions.
+- On failure, print the generating program (`show_ut_expr` / a `.cav`
+  pretty-print), `s0`, `s1`, `Q`, and the `verify` result.
+
+## Later / complementary (out of scope for v1)
+
+- **Counterexample-guided**: when `verify = Invalid`, extract a solver model
+  (add **Z3 via Why3**) and replay it through the interpreter to confirm; also
+  gives a second SMT backend for differential VC checking.
+- **Runtime contract checking** (`cav check`): execute while dynamically
+  asserting pre / invariants / post. Independent re-implementation of the
+  oracle; a bug would have to exist in both it and the WLP code to hide.
+- **Cheap targeted invariant**: have the interpreter record globals it actually
+  writes and assert ⊆ declared `writes` — catches the framing bug class with no
+  SMT at all.
+
+## Milestones
+
+1. [DONE] Fuel-bounded interpreter returning the final environment.
+   (`Runtime.exec_env` in `src/ast/runtime.ml`; overflow-checked arithmetic so
+   native 63-bit wraparound cannot masquerade as a counterexample; unit tests
+   in `test/program.ml`.)
+2. [DONE] `cmd` / expr / logic generators (no procedures), constructed-false-
+   triple property, wired into `dune runtest` at low count.
+   (`test/fuzz/fuzz.ml`; QCheck2 for integrated shrinking; `CAVALRY_FUZZ_COUNT`
+   env knob, default 20.)
+3. [DONE] Add the dual (true-`Q`) property. (Loop-free generator so the exact
+   postcondition is always discharged by the solver; `Failed`/timeout treated
+   as a skip, `Invalid` as a regression.)
+4. [TODO] Add procedure generation with random `writes` clauses. To give this
+   teeth against the framing bug class, generate procedures with `ensures
+   { true }` and *incomplete* `writes`, and build `Q` asserting the pre-state
+   is preserved: a correct `writes_are_declared` check rejects them (Invalid),
+   but removing the check lets the caller's WLP skip the havoc and "prove" the
+   false triple (Valid).
+5. [TODO] Shrinker tuning + a helper to emit a failing case as a `.cav`
+   fixture. (Failures currently print a readable sexp of the `cmd` plus `s0`,
+   `s1`, and `Q`; a `.cav` pretty-printer would let counterexamples drop
+   straight into `test/`.)
+
+## Validation
+
+The harness was smoke-tested by reintroducing the pre-fix unsound loop rule
+(dropping the havoc in `Hoare.Wlp.cmd`'s `While` case): the primary property
+fails and shrinks to `while c > 0 do t := k; c := c - 1 end` with invariant
+`true` and a false postcondition -- essentially `verify_false_loop_unquantified.cav`.
+With the correct rule restored it passes across seeds. The trivial invariant
+`true` is deliberately over-represented in the invariant generator because it
+is the shape that exposes this whole class.

--- a/cavalry.opam
+++ b/cavalry.opam
@@ -18,6 +18,7 @@ depends: [
   "why3"
   "alt-ergo" {= "2.4.3"}
   "ppx_deriving"
+  "qcheck-core" {with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -25,6 +25,7 @@
   menhir
   why3
   (alt-ergo (= "2.4.3"))
-  ppx_deriving))
+  ppx_deriving
+  (qcheck-core :with-test)))
 
 (using menhir 2.1)

--- a/src/ast/runtime.ml
+++ b/src/ast/runtime.ml
@@ -50,6 +50,34 @@ module Runtime = struct
     }
 end
 
+exception Out_of_fuel
+exception Overflow
+
+(* Overflow-checked native arithmetic, enabled only on the fuel-bounded path
+   ([exec_env]) used by the fuzzer. Cavalry integers are Why3's *unbounded*
+   [int]; the interpreter uses native 63-bit ints, so a concrete run that
+   overflows would silently diverge from the symbolic semantics and manufacture
+   spurious counterexamples. When [check_overflow] is set we detect the
+   divergence and abort the run (treated as a discard) instead. [cav run]
+   leaves the flag unset and keeps plain wrapping arithmetic. *)
+let check_overflow = ref false
+
+let add_ovf a b =
+  let s = a + b in
+  if !check_overflow && a lxor b >= 0 && a lxor s < 0 then raise Overflow;
+  s
+
+let sub_ovf a b =
+  let s = a - b in
+  if !check_overflow && a lxor b < 0 && a lxor s < 0 then raise Overflow;
+  s
+
+let mul_ovf a b =
+  let p = a * b in
+  if !check_overflow && a <> 0 && (p / a <> b || (a = -1 && b = min_int)) then
+    raise Overflow;
+  p
+
 let exec_value r (type a) (v : a value) : a =
   match v with
   | Unit () -> ()
@@ -64,13 +92,13 @@ let rec exec_expr : type a. Runtime.t -> a expr -> a =
   | Value v -> exec_value r v
   | Plus (a, b) ->
       let v1, v2 = binary_app r a b in
-      v1 + v2
+      add_ovf v1 v2
   | Sub (a, b) ->
       let v1, v2 = binary_app r a b in
-      v1 - v2
+      sub_ovf v1 v2
   | Mul (a, b) ->
       let v1, v2 = binary_app r a b in
-      v1 * v2
+      mul_ovf v1 v2
   | Eq (a, b) ->
       let v1, v2 = binary_app r a b in
       v1 = v2
@@ -90,7 +118,8 @@ let rec exec_expr : type a. Runtime.t -> a expr -> a =
       let v1, v2 = binary_app r a b in
       v1 >= v2
 
-and exec_cmd r c : int * Runtime.t =
+and exec_cmd ?(fuel = ref max_int) r c : int * Runtime.t =
+  let exec_cmd r c = exec_cmd ~fuel r c in
   match c with
   | Seq (c, c') ->
       let _, r' = exec_cmd r c in
@@ -118,9 +147,11 @@ and exec_cmd r c : int * Runtime.t =
       if b then exec_cmd r c else exec_cmd r c'
   | While (_, e, c) as loop ->
       let b = exec_expr r e in
-      if b then
+      if b then (
+        if !fuel <= 0 then raise Out_of_fuel;
+        decr fuel;
         let _, r' = exec_cmd r c in
-        exec_cmd r' loop
+        exec_cmd r' loop)
       else (0, r)
   | Print e ->
       Printf.printf "%d\n" (exec_expr r e);
@@ -136,3 +167,41 @@ let exec (ast : proc_t list) =
     List.fold_left (fun r proc -> Runtime.add_proc r proc) Runtime.empty procs
   in
   match main with { c = entrypoint; _ } -> fst @@ exec_cmd r entrypoint
+
+(* Outcome of a fuel-bounded run. [Terminated] exposes the whole final global
+   environment (not just the return value) so a differential harness can read
+   every variable to build a postcondition. [OutOfFuel] covers both the fuel
+   cap and detected overflow -- both mean "this run is not a usable witness",
+   so callers discard it. [Raised] is any other runtime failure, e.g. reading
+   an unbound variable. *)
+(* The environment a run ends in, keyed by variable name. Alias of the
+   interpreter's internal variable map, surfaced at the top level so callers
+   need not spell out the (confusingly self-named) nested [Runtime] module. *)
+module Env = Runtime.BoundVars
+
+type exec_result = Terminated of int Env.t | OutOfFuel | Raised
+
+(* Like [exec], but bounds loop iterations by [fuel] and returns the final
+   environment rather than the entrypoint's value. Used by the soundness
+   fuzzer, where non-termination must be discarded (WLP is only a *liberal*
+   precondition) rather than treated as a counterexample. *)
+let exec_env ?(fuel = 10000) (ast : proc_t list) : exec_result =
+  let main, procs =
+    let rev = List.rev ast in
+    (List.hd rev, List.tl rev |> List.rev)
+  in
+  let r =
+    List.fold_left (fun r proc -> Runtime.add_proc r proc) Runtime.empty procs
+  in
+  let fuel = ref fuel in
+  let entrypoint = main.c in
+  check_overflow := true;
+  Fun.protect
+    ~finally:(fun () -> check_overflow := false)
+    (fun () ->
+      try
+        let _, r' = exec_cmd ~fuel r entrypoint in
+        Terminated r'.global_vars
+      with
+      | Out_of_fuel | Overflow -> OutOfFuel
+      | Runtime.UnboundError _ -> Raised)

--- a/src/ast/runtime.mli
+++ b/src/ast/runtime.mli
@@ -1,4 +1,17 @@
 type proc_t = { f : string; ps : string list; c : Program.cmd }
 
+(* The final-state environment of a run, keyed by variable name. *)
+module Env : Map.S with type key = string
+
 val to_proc_t : Triple.t -> proc_t
 val exec : proc_t list -> int
+
+(* Outcome of a fuel-bounded run; [Terminated] carries the final global
+   environment. [OutOfFuel] also covers detected arithmetic overflow. *)
+type exec_result = Terminated of int Env.t | OutOfFuel | Raised
+
+val exec_env : ?fuel:int -> proc_t list -> exec_result
+(** Fuel-bounded interpreter returning the final global environment rather than
+    the entrypoint value. Non-terminating runs (loops exceeding [fuel]) and
+    overflowing runs yield [OutOfFuel]; a differential harness discards these.
+    [fuel] bounds total loop iterations (default 10000). *)

--- a/test/fuzz/dune
+++ b/test/fuzz/dune
@@ -1,0 +1,8 @@
+; QuickCheck-based soundness harness: differential test between the symbolic
+; verifier (Hoare.verify) and the concrete interpreter (Runtime.exec_env).
+; Runs a small number of iterations under `dune runtest`; crank it up with the
+; CAVALRY_FUZZ_COUNT environment variable for longer local/nightly sessions.
+
+(test
+ (name fuzz)
+ (libraries cavalry ast smt why3 core qcheck-core qcheck-core.runner))

--- a/test/fuzz/fuzz.ml
+++ b/test/fuzz/fuzz.ml
@@ -1,0 +1,333 @@
+(* QuickCheck-based soundness harness for [Hoare.verify].
+
+   Strategy (see PLAN.md): rather than generate random pre/postconditions and
+   hope to hit the [Valid] branch, we construct triples that are *definitely
+   false* and assert the verifier never accepts them. The interpreter
+   ([Runtime.exec_env]) is the oracle -- an independent implementation of the
+   language semantics -- so this is a differential test between the symbolic
+   verifier and concrete execution.
+
+   For a generated command [c] and a concrete initial state [s0]:
+     1. run [c] from [s0] with fuel; discard non-terminating/overflowing runs
+        (partial correctness => non-termination is not a counterexample);
+     2. build [p] pinning [s0] exactly, so the triple ranges over one state;
+     3. build [q_false] false on the final state [s1];
+     4. property: verify {p} c {q_false} MUST be Invalid. A Valid is a
+        minimized soundness bug. *)
+
+module Program = Ast.Program
+module Logic = Ast.Logic
+module Triple = Ast.Triple
+module Runtime = Ast.Runtime
+module Var_collection = Ast.Var_collection
+module Hoare = Cavalry.Hoare
+module Prover = Smt.Prover
+module G = QCheck2.Gen
+
+(* Small fixed variable pool so aliasing and name collisions actually occur. *)
+let pool = [ "x"; "y"; "z"; "i"; "j" ]
+let verify_timeout = 3.0
+
+(* ===== Generators ============================================= *)
+
+let gen_var = G.oneof_list pool
+
+(* Literals are non-negative: Cavalry has no negative literals (they lex as
+   naturals), and Why3's [t_nat_const] rejects negative constants. Negative
+   *values* still arise at runtime through subtraction. *)
+let gen_lit = G.int_range 0 8
+
+(* Encode an arbitrary (possibly negative) integer as a Logic arith term,
+   writing negatives as [0 - n] to match the surface language. Used to pin
+   concrete state values (which can be negative) in [p] and [q]. *)
+let logic_int v =
+  if v >= 0 then Logic.Int v else Logic.Sub (Logic.Int 0, Logic.Int (-v))
+
+(* int expr over the pool; literals in a small range so nonlinear terms stay
+   small and concrete runs terminate quickly. *)
+let rec gen_int_expr n =
+  let open Program in
+  if n <= 1 then
+    G.oneof
+      [
+        G.map (fun i -> Value (Int i)) gen_lit;
+        G.map (fun x -> Value (VarInst x)) gen_var;
+      ]
+  else
+    G.oneof_weighted
+      [
+        (3, gen_int_expr 1);
+        ( 1,
+          let sub = gen_int_expr (n / 2) in
+          G.bind
+            (G.oneof_list [ `P; `S; `M ])
+            (fun op ->
+              G.map2
+                (fun a b ->
+                  match op with
+                  | `P -> Plus (a, b)
+                  | `S -> Sub (a, b)
+                  | `M -> Mul (a, b))
+                sub sub) );
+      ]
+
+let gen_bool_expr n =
+  let open Program in
+  let half = max 1 (n / 2) in
+  G.bind
+    (G.oneof_list [ `Eq; `Neq; `Lt; `Leq; `Gt; `Geq ])
+    (fun op ->
+      G.map2
+        (fun a b ->
+          match op with
+          | `Eq -> Eq (a, b)
+          | `Neq -> Neq (a, b)
+          | `Lt -> Lt (a, b)
+          | `Leq -> Leq (a, b)
+          | `Gt -> Gt (a, b)
+          | `Geq -> Geq (a, b))
+        (gen_int_expr half) (gen_int_expr half))
+
+(* A loop invariant: any well-formed [Logic.expr] over the pool. It need not be
+   a true invariant -- the constructed-false-triple property holds regardless
+   (a bad invariant only makes [verify] more likely to answer Invalid). *)
+let rec gen_l_arith n =
+  let open Logic in
+  if n <= 1 then
+    G.oneof [ G.map (fun i -> Int i) gen_lit; G.map (fun x -> Var x) gen_var ]
+  else
+    G.bind
+      (G.oneof_list [ `P; `S; `M ])
+      (fun op ->
+        G.map2
+          (fun a b ->
+            match op with
+            | `P -> Plus (a, b)
+            | `S -> Sub (a, b)
+            | `M -> Mul (a, b))
+          (gen_l_arith (n / 2))
+          (gen_l_arith (n / 2)))
+
+let gen_comparison =
+  let open Logic in
+  G.bind
+    (G.oneof_list [ `Eq; `Neq; `Lt; `Leq; `Gt; `Geq ])
+    (fun op ->
+      G.map2
+        (fun a b ->
+          match op with
+          | `Eq -> Eq (a, b)
+          | `Neq -> Neq (a, b)
+          | `Lt -> Lt (a, b)
+          | `Leq -> Leq (a, b)
+          | `Gt -> Gt (a, b)
+          | `Geq -> Geq (a, b))
+        (gen_l_arith 2) (gen_l_arith 2))
+
+(* Include the trivial invariants prominently. [true] is the single most
+   important invariant to test: it holds on entry and is inductive, so it is
+   exactly what exposes an unsound loop rule that fails to havoc the variables
+   the body modifies (a false postcondition then "verifies" whenever the loop
+   runs at least once). *)
+let gen_invariant =
+  G.oneof_weighted
+    [
+      (2, G.pure (Logic.Bool true));
+      (1, G.pure (Logic.Bool false));
+      (3, gen_comparison);
+    ]
+
+let gen_assgn =
+  G.map2 (fun x e -> Program.Assgn (x, e)) gen_var (gen_int_expr 3)
+
+(* Loop-free command generator: assignments, sequencing, conditionals. Used for
+   the dual (true-postcondition) property, where WLP is exact and the solver
+   should always discharge the concrete goal. *)
+let rec gen_cmd_loopfree n =
+  let open Program in
+  if n <= 1 then gen_assgn
+  else
+    G.oneof_weighted
+      [
+        (4, gen_assgn);
+        ( 3,
+          G.map2
+            (fun a b -> Seq (a, b))
+            (gen_cmd_loopfree (n / 2))
+            (gen_cmd_loopfree (n / 2)) );
+        ( 2,
+          G.map3
+            (fun b c c' -> If (b, c, c'))
+            (gen_bool_expr 2)
+            (gen_cmd_loopfree (n / 2))
+            (gen_cmd_loopfree (n / 2)) );
+      ]
+
+(* A guaranteed-terminating counting loop:
+
+     while c > 0 do <inv> t := e; c := c - 1 end
+
+   The dedicated counter [c] strictly decreases and is not touched by the extra
+   assignment (t <> c), so the loop always terminates and runs [s0(c)]
+   iterations -- >= 1 whenever [s0(c) > 0]. This reliably exercises the loop
+   rule (unlike a fully random guard, which usually diverges and is discarded).
+   With [inv = true] it is exactly the shape that exposes an unsound loop rule
+   that forgets to havoc the variables the body modifies. *)
+let gen_while =
+  let open Program in
+  G.bind (G.oneof_list pool) (fun c ->
+      let others = List.filter (fun v -> v <> c) pool in
+      G.bind gen_invariant (fun inv ->
+          G.map2
+            (fun t e ->
+              let decr = Assgn (c, Sub (Value (VarInst c), Value (Int 1))) in
+              let guard = Gt (Value (VarInst c), Value (Int 0)) in
+              While (inv, guard, Seq (Assgn (t, e), decr)))
+            (G.oneof_list others) (gen_int_expr 3)))
+
+(* Full command generator: adds shallow, rare [While] loops. Used for the
+   primary soundness property. Loops are kept rare and shallow so most runs
+   terminate within fuel; those that do not are discarded. *)
+let rec gen_cmd_full n =
+  let open Program in
+  if n <= 1 then gen_assgn
+  else
+    G.oneof_weighted
+      [
+        (4, gen_assgn);
+        ( 3,
+          G.map2
+            (fun a b -> Seq (a, b))
+            (gen_cmd_full (n / 2))
+            (gen_cmd_full (n / 2)) );
+        ( 2,
+          G.map3
+            (fun b c c' -> If (b, c, c'))
+            (gen_bool_expr 2)
+            (gen_cmd_full (n / 2))
+            (gen_cmd_full (n / 2)) );
+        (1, gen_while);
+      ]
+
+(* s0: a random binding for every pool variable, so every read in [c] is
+   defined. Generated alongside [c] so shrinking coordinates the two. *)
+let gen_s0 =
+  G.map
+    (fun vals -> List.combine pool vals)
+    (G.list_size (G.return (List.length pool)) gen_lit)
+
+let gen_case gen_cmd = G.pair gen_s0 (G.sized_size (G.int_range 2 6) gen_cmd)
+
+(* ===== Building triples and running the oracle ================ *)
+
+(* Prepend [x := s0(x)] for every pool variable, so the interpreter starts from
+   the concrete state [s0]. (The verifier gets [s0] symbolically via [p], so it
+   is run on the bare [c].) *)
+let seed_cmd s0 c =
+  List.fold_right
+    (fun (x, v) acc ->
+      Program.Seq (Program.Assgn (x, Program.Value (Program.Int v)), acc))
+    s0 c
+
+let run s0 c =
+  let body = seed_cmd s0 c in
+  Runtime.exec_env ~fuel:2000 [ { Runtime.f = ""; ps = []; c = body } ]
+
+(* p = /\_x  x = s0(x) : pins the initial state to exactly [s0]. *)
+let build_p s0 =
+  List.fold_left
+    (fun acc (x, v) -> Logic.And (acc, Logic.Eq (Logic.Var x, logic_int v)))
+    (Logic.Bool true) s0
+
+(* q_false = (x = s1(x) + 1) : definitely false on the final state. *)
+let build_false_q env =
+  match Runtime.Env.find_opt "x" env with
+  | None -> None
+  | Some v -> Some (Logic.Eq (Logic.Var "x", logic_int (v + 1)))
+
+(* q_true = /\_x  x = s1(x) : the exact (definitely true) postcondition. *)
+let build_true_q env =
+  Runtime.Env.fold
+    (fun x v acc -> Logic.And (acc, Logic.Eq (Logic.Var x, logic_int v)))
+    env (Logic.Bool true)
+
+let verify_triple p q c =
+  let triple = { Triple.p; q; ws = []; f = ""; ps = []; c } in
+  let collected = Var_collection.collect [ triple ] in
+  Hoare.verify ?timeout:(Some verify_timeout) collected
+
+(* ===== Properties ============================================= *)
+
+(* Primary: a false postcondition must be rejected. A [Valid] is a soundness
+   bug. Non-terminating runs and prover failures/timeouts are not witnesses, so
+   they pass trivially. *)
+let prop_false_rejected (s0, c) =
+  match run s0 c with
+  | Runtime.OutOfFuel | Runtime.Raised -> true
+  | Runtime.Terminated env -> (
+      match build_false_q env with
+      | None -> true
+      | Some q -> (
+          match verify_triple (build_p s0) q c with
+          | Prover.Valid -> false
+          | Prover.Invalid | Prover.Failed _ -> true))
+
+(* Dual: the exact (true) postcondition should be accepted on a fully-concrete,
+   loop-free triple (all linear, so the solver should close it). Failures here
+   are not unsoundness but catch regressions / gross incompleteness. *)
+let prop_true_accepted (s0, c) =
+  match run s0 c with
+  | Runtime.OutOfFuel | Runtime.Raised -> true
+  | Runtime.Terminated env -> (
+      match verify_triple (build_p s0) (build_true_q env) c with
+      | Prover.Valid -> true
+      | Prover.Failed _ -> true (* solver resource limit: not a regression *)
+      | Prover.Invalid -> false)
+
+(* ===== Reporting ============================================= *)
+
+let cmd_to_string c = Core.Sexp.to_string_hum (Program.sexp_of_cmd c)
+let logic_to_string e = Core.Sexp.to_string_hum (Logic.sexp_of_expr e)
+
+let s0_to_string s0 =
+  String.concat ", " (List.map (fun (x, v) -> Printf.sprintf "%s=%d" x v) s0)
+
+let print_case ~q_of (s0, c) =
+  let outcome =
+    match run s0 c with
+    | Runtime.Terminated env ->
+        let s1 =
+          Runtime.Env.fold (fun x v acc -> (x, v) :: acc) env []
+          |> List.rev
+          |> List.map (fun (x, v) -> Printf.sprintf "%s=%d" x v)
+          |> String.concat ", "
+        in
+        Printf.sprintf "s1: {%s}\nq:  %s" s1
+          (match q_of env with Some q -> logic_to_string q | None -> "<none>")
+    | Runtime.OutOfFuel -> "out of fuel"
+    | Runtime.Raised -> "raised"
+  in
+  Printf.sprintf "s0: {%s}\ncmd:\n%s\n%s" (s0_to_string s0) (cmd_to_string c)
+    outcome
+
+(* ===== Wiring ============================================= *)
+
+let count =
+  match Sys.getenv_opt "CAVALRY_FUZZ_COUNT" with
+  | Some s -> ( try int_of_string s with _ -> 20)
+  | None -> 20
+
+let test_false_rejected =
+  QCheck2.Test.make ~count ~name:"soundness: false postcondition is rejected"
+    ~print:(print_case ~q_of:build_false_q)
+    (gen_case gen_cmd_full) prop_false_rejected
+
+let test_true_accepted =
+  QCheck2.Test.make ~count
+    ~name:"regression: true postcondition is accepted (loop-free)"
+    ~print:(print_case ~q_of:(fun env -> Some (build_true_q env)))
+    (gen_case gen_cmd_loopfree)
+    prop_true_accepted
+
+let () =
+  QCheck_base_runner.run_tests_main [ test_false_rejected; test_true_accepted ]

--- a/test/fuzz/fuzz.ml
+++ b/test/fuzz/fuzz.ml
@@ -251,10 +251,94 @@ let build_true_q env =
     (fun x v acc -> Logic.And (acc, Logic.Eq (Logic.Var x, logic_int v)))
     env (Logic.Bool true)
 
-let verify_triple p q c =
-  let triple = { Triple.p; q; ws = []; f = ""; ps = []; c } in
-  let collected = Var_collection.collect [ triple ] in
-  Hoare.verify ?timeout:(Some verify_timeout) collected
+let main_triple ~p ~q ~c : Triple.t = { p; q; ws = []; f = "main"; ps = []; c }
+
+let verify_program (triples : Triple.t list) =
+  Hoare.verify ?timeout:(Some verify_timeout) (Var_collection.collect triples)
+
+(* ===== Procedure generation (framing) ========================= *)
+
+(* Each non-hidden pool variable plays one of three roles in the generated
+   procedure [f]: it is either not written, written and declared in [writes],
+   or written but *not* declared (an incomplete writes clause). This directly
+   generates "random writes clauses, including deliberately incomplete ones". *)
+type role = Skip | Declared of int | Undeclared of int
+
+let gen_role =
+  G.oneof_weighted
+    [
+      (2, G.pure Skip);
+      (2, G.map (fun k -> Declared k) (G.int_range 1 8));
+      (2, G.map (fun k -> Undeclared k) (G.int_range 1 8));
+    ]
+
+(* A framing case: an initial state, a distinguished [hidden] global that [f]
+   always writes (by [+kh], so it definitely changes) but *never* declares, and
+   a role for every other pool variable. [hidden] is the guaranteed incomplete
+   write that gives this property teeth against a missing [writes] check. *)
+let gen_framing =
+  G.bind gen_s0 (fun s0 ->
+      G.bind (G.oneof_list pool) (fun hidden ->
+          G.bind (G.int_range 1 8) (fun kh ->
+              let others = List.filter (fun v -> v <> hidden) pool in
+              G.map
+                (fun roles -> (s0, hidden, kh, List.combine others roles))
+                (G.flatten_list (List.map (fun _ -> gen_role) others)))))
+
+let framing_body hidden kh roles =
+  let open Program in
+  let assign v k = Assgn (v, Plus (Value (VarInst v), Value (Int k))) in
+  let stmts =
+    assign hidden kh
+    :: List.filter_map
+         (fun (v, role) ->
+           match role with
+           | Skip -> None
+           | Declared k | Undeclared k -> Some (assign v k))
+         roles
+  in
+  List.fold_left (fun acc st -> Seq (acc, st)) (List.hd stmts) (List.tl stmts)
+
+let framing_writes roles =
+  List.filter_map
+    (fun (v, role) -> match role with Declared _ -> Some v | _ -> None)
+    roles
+
+(* Triples for a framing case:
+
+     procedure f () = requires { true } ensures { true } writes { <declared> }
+       hidden := hidden + kh; <other writes>
+     end
+     { P }  f()  { hidden = s0(hidden) }
+
+   [f]'s postcondition tells the caller nothing, and [hidden] is written but
+   undeclared. A correct [writes_are_declared] check rejects [f] outright
+   (Invalid). Drop the check and the caller's WLP no longer havocs [hidden], so
+   it "proves" it is unchanged (Valid) -- while the interpreter changed it. This
+   is the minimized shape of [verify_false_writes_undeclared.cav]. *)
+let framing_triples (s0, hidden, kh, roles) : Triple.t list =
+  let f : Triple.t =
+    {
+      p = Logic.Bool true;
+      q = Logic.Bool true;
+      ws = framing_writes roles;
+      f = "f";
+      ps = [];
+      c = framing_body hidden kh roles;
+    }
+  in
+  let q = Logic.Eq (Logic.Var hidden, logic_int (List.assoc hidden s0)) in
+  [ f; main_triple ~p:(build_p s0) ~q ~c:(Program.Proc ("f", [])) ]
+
+(* Execute a framing case through the interpreter: main seeds [s0] then calls
+   [f]. [f]'s global writes persist to main, so the final environment shows the
+   real effect of the (partially undeclared) writes. *)
+let run_framing (s0, hidden, kh, roles) =
+  let f_proc = { Runtime.f = "f"; ps = []; c = framing_body hidden kh roles } in
+  let main_proc =
+    { Runtime.f = "main"; ps = []; c = seed_cmd s0 (Program.Proc ("f", [])) }
+  in
+  Runtime.exec_env ~fuel:2000 [ f_proc; main_proc ]
 
 (* ===== Properties ============================================= *)
 
@@ -268,7 +352,7 @@ let prop_false_rejected (s0, c) =
       match build_false_q env with
       | None -> true
       | Some q -> (
-          match verify_triple (build_p s0) q c with
+          match verify_program [ main_triple ~p:(build_p s0) ~q ~c ] with
           | Prover.Valid -> false
           | Prover.Invalid | Prover.Failed _ -> true))
 
@@ -279,36 +363,172 @@ let prop_true_accepted (s0, c) =
   match run s0 c with
   | Runtime.OutOfFuel | Runtime.Raised -> true
   | Runtime.Terminated env -> (
-      match verify_triple (build_p s0) (build_true_q env) c with
+      let q = build_true_q env in
+      match verify_program [ main_triple ~p:(build_p s0) ~q ~c ] with
       | Prover.Valid -> true
       | Prover.Failed _ -> true (* solver resource limit: not a regression *)
       | Prover.Invalid -> false)
 
-(* ===== Reporting ============================================= *)
+(* Framing: a procedure with an incomplete [writes] clause must never let a
+   caller "prove" a false triple. The interpreter confirms [hidden] really
+   changed (differential sanity); then [verify] must answer Invalid. A [Valid]
+   is a framing soundness bug. *)
+let prop_framing ((s0, hidden, _, _) as case) =
+  match run_framing case with
+  | Runtime.OutOfFuel | Runtime.Raised -> true
+  | Runtime.Terminated env -> (
+      match Runtime.Env.find_opt hidden env with
+      | Some v when v = List.assoc hidden s0 -> true (* unchanged: skip *)
+      | _ -> (
+          match verify_program (framing_triples case) with
+          | Prover.Valid -> false
+          | Prover.Invalid | Prover.Failed _ -> true))
 
-let cmd_to_string c = Core.Sexp.to_string_hum (Program.sexp_of_cmd c)
-let logic_to_string e = Core.Sexp.to_string_hum (Logic.sexp_of_expr e)
+(* ===== .cav pretty-printer =================================== *)
+
+(* Render a failing case as surface-syntax Cavalry, so a counterexample can be
+   dropped straight into test/ as a regression fixture. Binary operators are
+   fully parenthesised to sidestep precedence; negatives are written [0 - n]. *)
+
+let indent n s =
+  let pad = String.make n ' ' in
+  String.split_on_char '\n' s
+  |> List.map (fun l -> pad ^ l)
+  |> String.concat "\n"
+
+let value_to_cav : type a. a Program.value -> string = function
+  | Program.Int i -> string_of_int i
+  | Program.Bool b -> string_of_bool b
+  | Program.VarInst x -> x
+  | Program.Unit () -> "()"
+
+let rec expr_to_cav : type a. a Program.expr -> string =
+ fun e ->
+  let bin op a b =
+    Printf.sprintf "(%s %s %s)" (expr_to_cav a) op (expr_to_cav b)
+  in
+  match e with
+  | Program.Value v -> value_to_cav v
+  | Program.Plus (a, b) -> bin "+" a b
+  | Program.Sub (a, b) -> bin "-" a b
+  | Program.Mul (a, b) -> bin "*" a b
+  | Program.Eq (a, b) -> bin "=" a b
+  | Program.Neq (a, b) -> bin "!=" a b
+  | Program.Lt (a, b) -> bin "<" a b
+  | Program.Leq (a, b) -> bin "<=" a b
+  | Program.Gt (a, b) -> bin ">" a b
+  | Program.Geq (a, b) -> bin ">=" a b
+
+let rec arith_to_cav = function
+  | Logic.Int i -> string_of_int i
+  | Logic.Var x -> x
+  | Logic.Plus (a, b) ->
+      Printf.sprintf "(%s + %s)" (arith_to_cav a) (arith_to_cav b)
+  | Logic.Sub (a, b) ->
+      Printf.sprintf "(%s - %s)" (arith_to_cav a) (arith_to_cav b)
+  | Logic.Mul (a, b) ->
+      Printf.sprintf "(%s * %s)" (arith_to_cav a) (arith_to_cav b)
+
+(* The grammar has no parenthesised-[logic_expr] rule (only [arith_expr] can be
+   parenthesised), so boolean connectives and comparisons are emitted bare and
+   rely on the declared precedence: [&&] is left-associative and comparisons
+   bind tighter, which faithfully reproduces the left-nested [And] of
+   comparisons this harness generates for P and Q. *)
+let rec logic_to_cav = function
+  | Logic.Bool b -> string_of_bool b
+  | Logic.Not e -> Printf.sprintf "!%s" (logic_to_cav e)
+  | Logic.And (a, b) ->
+      Printf.sprintf "%s && %s" (logic_to_cav a) (logic_to_cav b)
+  | Logic.Or (a, b) ->
+      Printf.sprintf "%s || %s" (logic_to_cav a) (logic_to_cav b)
+  | Logic.Impl (a, b) ->
+      Printf.sprintf "%s -> %s" (logic_to_cav a) (logic_to_cav b)
+  | Logic.Eq (a, b) ->
+      Printf.sprintf "%s = %s" (arith_to_cav a) (arith_to_cav b)
+  | Logic.Neq (a, b) ->
+      Printf.sprintf "%s != %s" (arith_to_cav a) (arith_to_cav b)
+  | Logic.Lt (a, b) ->
+      Printf.sprintf "%s < %s" (arith_to_cav a) (arith_to_cav b)
+  | Logic.Leq (a, b) ->
+      Printf.sprintf "%s <= %s" (arith_to_cav a) (arith_to_cav b)
+  | Logic.Gt (a, b) ->
+      Printf.sprintf "%s > %s" (arith_to_cav a) (arith_to_cav b)
+  | Logic.Geq (a, b) ->
+      Printf.sprintf "%s >= %s" (arith_to_cav a) (arith_to_cav b)
+
+let rec cmd_to_cav c =
+  match c with
+  | Program.Assgn (x, e) -> Printf.sprintf "%s <- %s" x (expr_to_cav e)
+  | Program.Let (x, e) -> Printf.sprintf "%s <- %s" x (expr_to_cav e)
+  | Program.Seq (a, b) -> Printf.sprintf "%s;\n%s" (cmd_to_cav a) (cmd_to_cav b)
+  | Program.If (b, c0, c1) ->
+      Printf.sprintf "if %s then\n%s\nelse\n%s\nend" (expr_to_cav b)
+        (indent 2 (cmd_to_cav c0))
+        (indent 2 (cmd_to_cav c1))
+  | Program.While (inv, b, body) ->
+      Printf.sprintf "while %s do\n  invariant { %s }\n%s\nend" (expr_to_cav b)
+        (logic_to_cav inv)
+        (indent 2 (cmd_to_cav body))
+  | Program.Proc (f, ps) ->
+      Printf.sprintf "%s(%s)" f (String.concat ", " (List.map expr_to_cav ps))
+  | Program.IntExpr e -> expr_to_cav e
+  | Program.Print e -> Printf.sprintf "print %s" (expr_to_cav e)
+
+let proc_to_cav (t : Triple.t) =
+  Printf.sprintf
+    "procedure %s (%s) =\n\
+    \  requires { %s }\n\
+    \  ensures { %s }\n\
+    \  writes { %s }\n\
+     %s\n\
+     end"
+    t.f (String.concat ", " t.ps) (logic_to_cav t.p) (logic_to_cav t.q)
+    (String.concat ", " t.ws)
+    (indent 2 (cmd_to_cav t.c))
+
+let main_to_cav (t : Triple.t) =
+  Printf.sprintf "{ %s }\n%s\n{ %s }" (logic_to_cav t.p) (cmd_to_cav t.c)
+    (logic_to_cav t.q)
+
+let emit_cav (triples : Triple.t list) =
+  let procs, main =
+    match List.rev triples with
+    | last :: rev_procs -> (List.rev rev_procs, last)
+    | [] ->
+        ( [],
+          main_triple ~p:(Logic.Bool true) ~q:(Logic.Bool true)
+            ~c:(Program.IntExpr (Program.Value (Program.Int 0))) )
+  in
+  String.concat "\n\n" (List.map proc_to_cav procs @ [ main_to_cav main ])
+
+(* ===== Reporting ============================================= *)
 
 let s0_to_string s0 =
   String.concat ", " (List.map (fun (x, v) -> Printf.sprintf "%s=%d" x v) s0)
 
-let print_case ~q_of (s0, c) =
-  let outcome =
-    match run s0 c with
-    | Runtime.Terminated env ->
-        let s1 =
-          Runtime.Env.fold (fun x v acc -> (x, v) :: acc) env []
-          |> List.rev
-          |> List.map (fun (x, v) -> Printf.sprintf "%s=%d" x v)
-          |> String.concat ", "
-        in
-        Printf.sprintf "s1: {%s}\nq:  %s" s1
-          (match q_of env with Some q -> logic_to_string q | None -> "<none>")
-    | Runtime.OutOfFuel -> "out of fuel"
-    | Runtime.Raised -> "raised"
-  in
-  Printf.sprintf "s0: {%s}\ncmd:\n%s\n%s" (s0_to_string s0) (cmd_to_string c)
-    outcome
+let env_to_string env =
+  Runtime.Env.fold (fun x v acc -> (x, v) :: acc) env []
+  |> List.rev
+  |> List.map (fun (x, v) -> Printf.sprintf "%s=%d" x v)
+  |> String.concat ", "
+
+let outcome_to_string = function
+  | Runtime.Terminated env -> Printf.sprintf "s1: {%s}" (env_to_string env)
+  | Runtime.OutOfFuel -> "out of fuel"
+  | Runtime.Raised -> "raised"
+
+let print_case ~triples_of (s0, c) =
+  let triples = triples_of (s0, c) in
+  Printf.sprintf "s0: {%s}\n%s\n\n.cav:\n%s" (s0_to_string s0)
+    (outcome_to_string (run s0 c))
+    (match triples with Some t -> emit_cav t | None -> "<no triple>")
+
+let print_framing ((s0, hidden, kh, _) as case) =
+  Printf.sprintf
+    "s0: {%s}\nhidden (undeclared write): %s (+%d)\n%s\n\n.cav:\n%s"
+    (s0_to_string s0) hidden kh
+    (outcome_to_string (run_framing case))
+    (emit_cav (framing_triples case))
 
 (* ===== Wiring ============================================= *)
 
@@ -318,16 +538,35 @@ let count =
   | None -> 20
 
 let test_false_rejected =
+  let triples_of (s0, c) =
+    match run s0 c with
+    | Runtime.Terminated env ->
+        Option.map
+          (fun q -> [ main_triple ~p:(build_p s0) ~q ~c ])
+          (build_false_q env)
+    | Runtime.OutOfFuel | Runtime.Raised -> None
+  in
   QCheck2.Test.make ~count ~name:"soundness: false postcondition is rejected"
-    ~print:(print_case ~q_of:build_false_q)
-    (gen_case gen_cmd_full) prop_false_rejected
+    ~print:(print_case ~triples_of) (gen_case gen_cmd_full) prop_false_rejected
 
 let test_true_accepted =
+  let triples_of (s0, c) =
+    match run s0 c with
+    | Runtime.Terminated env ->
+        Some [ main_triple ~p:(build_p s0) ~q:(build_true_q env) ~c ]
+    | Runtime.OutOfFuel | Runtime.Raised -> None
+  in
   QCheck2.Test.make ~count
     ~name:"regression: true postcondition is accepted (loop-free)"
-    ~print:(print_case ~q_of:(fun env -> Some (build_true_q env)))
+    ~print:(print_case ~triples_of)
     (gen_case gen_cmd_loopfree)
     prop_true_accepted
 
+let test_framing =
+  QCheck2.Test.make ~count
+    ~name:"soundness: incomplete writes clause is rejected" ~print:print_framing
+    gen_framing prop_framing
+
 let () =
-  QCheck_base_runner.run_tests_main [ test_false_rejected; test_true_accepted ]
+  QCheck_base_runner.run_tests_main
+    [ test_false_rejected; test_true_accepted; test_framing ]

--- a/test/program.ml
+++ b/test/program.ml
@@ -123,6 +123,60 @@ let%test_unit "Ast.Runtime.exec - while" =
   let result = exec [ main ] in
   [%test_result: int] result ~expect:45
 
+let dummy_invariant = Logic.(Eq (Int 1, Int 2))
+
+(* Fuel-bounded exec exposes the final environment, not just the return value.
+   x := 0; i := 0; while i < 3 do x := x + i; i := i + 1 end
+   terminates at x = 0+1+2 = 3, i = 3. *)
+let%test_unit "Ast.Runtime.exec_env - terminating loop returns final env" =
+  let c =
+    Seq
+      ( Assgn ("x", Value (Int 0)),
+        Seq
+          ( Assgn ("i", Value (Int 0)),
+            While
+              ( dummy_invariant,
+                Lt (Value (VarInst "i"), Value (Int 3)),
+                Seq
+                  ( Assgn ("x", Plus (Value (VarInst "x"), Value (VarInst "i"))),
+                    Assgn ("i", Plus (Value (VarInst "i"), Value (Int 1))) ) )
+          ) )
+  in
+  match exec_env ~fuel:100 [ { f = ""; ps = []; c } ] with
+  | Terminated env ->
+      [%test_result: int option] (Env.find_opt "x" env) ~expect:(Some 3);
+      [%test_result: int option] (Env.find_opt "i" env) ~expect:(Some 3)
+  | OutOfFuel | Raised -> assert false
+
+(* A loop whose guard never falsifies is discarded (OutOfFuel), not run
+   forever -- partial correctness means non-termination is not a witness. *)
+let%test_unit "Ast.Runtime.exec_env - non-terminating loop runs out of fuel" =
+  let c =
+    Seq
+      ( Assgn ("i", Value (Int 0)),
+        While
+          ( dummy_invariant,
+            Lt (Value (Int 0), Value (Int 1)),
+            Assgn ("i", Plus (Value (VarInst "i"), Value (Int 1))) ) )
+  in
+  let out_of_fuel =
+    match exec_env ~fuel:50 [ { f = ""; ps = []; c } ] with
+    | OutOfFuel -> true
+    | Terminated _ | Raised -> false
+  in
+  [%test_result: bool] out_of_fuel ~expect:true
+
+(* Reading an unbound variable is reported as [Raised], not an escaping
+   exception. *)
+let%test_unit "Ast.Runtime.exec_env - unbound read is Raised" =
+  let c = IntExpr (Plus (Value (VarInst "x"), Value (Int 2))) in
+  let raised =
+    match exec_env [ { f = ""; ps = []; c } ] with
+    | Raised -> true
+    | Terminated _ | OutOfFuel -> false
+  in
+  [%test_result: bool] raised ~expect:true
+
 let%test_unit "Ast.Runtime.exec - function" =
   (* f(z) = let y = z + 1; x := x + y *)
   let fn : Triple.ut_t =


### PR DESCRIPTION
## What

A QuickCheck-based **soundness** harness for `Hoare.verify`: a differential test between the symbolic verifier and the concrete interpreter (`Runtime.exec_env`), which is the independent oracle. It targets the exact bug class both fixes on `main` addressed — `verify = Valid` while `exec` reaches a state contradicting `Q`.

Implements all of `PLAN.md` (milestones 1–5).

## How it works

Rather than generate random pre/postconditions and hope to hit the `Valid` branch, it constructs triples that are *definitely false* and asserts the verifier never accepts them:

1. Generate a well-typed `cmd` and a concrete initial state `s0`.
2. Run it with fuel; discard non-terminating/overflowing runs (partial correctness ⇒ non-termination is not a counterexample).
3. Build `P` pinning `s0` exactly and `Q` false on the final state `s1`.
4. Property: `verify {P} c {Q}` **must** be `Invalid`; a `Valid` is a minimized soundness bug.

Three properties: primary (false postcondition rejected), dual (exact postcondition accepted on loop-free programs — a regression/incompleteness signal), and framing (incomplete `writes` clause rejected).

## Commits

- **Fuel-bounded interpreter** (`Runtime.exec_env`) returning the final environment, with overflow-checked arithmetic so native 63-bit wraparound can't masquerade as a counterexample.
- **Harness v1**: QCheck2 generators + primary/dual properties, wired into `dune runtest` at a low count with a `CAVALRY_FUZZ_COUNT` env knob.
- **Framing property + `.cav` emitter**: procedure generation with random (incl. incomplete) `writes` clauses; failures print a ready-to-paste `.cav` fixture.

## Validation

Reintroducing each bug this branch's target class covers makes the harness fail and shrink to a minimal `.cav`:

- Dropping the loop havoc ⇒ shrinks to essentially `verify_false_loop_unquantified.cav`.
- Disabling the `writes_are_declared` guard ⇒ shrinks to essentially `verify_false_writes_undeclared.cav` (round-tripped through `cav verify`).

With correct code, all three properties pass across seeds.

## Test plan

- [x] `dune build @fmt`, `dune build`, `dune runtest` all green
- [x] full suite (inline + fuzz ×3) ~2.4s
- [x] stress: count 120 across seeds 1/11/42/99, all pass
- [x] emitter round-trips through the real parser/verifier

Adds `qcheck-core` as a `{with-test}` dependency (installed by CI's `opam install . --deps-only --with-test`).

## Usage

```bash
dune runtest                                        # default 20 iters/property
CAVALRY_FUZZ_COUNT=5000 dune exec -- test/fuzz/fuzz.exe        # longer session
CAVALRY_FUZZ_COUNT=5000 dune exec -- test/fuzz/fuzz.exe -s 42  # reproduce a seed
```