### PR TITLE
feat: add self-recursion via decreasing variants

### DIFF
--- a/src/ast/parse/program.mly
+++ b/src/ast/parse/program.mly
@@ -2,6 +2,7 @@
 %type <Ast.Triple.ut_t list> top
 %type <Ast.Triple.ut_t> main
 %type <Ast.Triple.ut_t> procedure
+%type <Ast.Logic.arith_expr option> variant_opt
 %type <string list> variable_list
 %type <Ast.Program.ut_expr> command
 %type <Ast.Program.ut_expr> expr
@@ -16,8 +17,14 @@ top:
       { [ m ] }
 ;
 procedure:
-  | PROCEDURE f = VAR LPAREN ps = variable_list RPAREN EQ REQUIRES LBRACE p = logic_expr RBRACE ENSURES LBRACE q = logic_expr RBRACE WRITES LBRACE ws = variable_list RBRACE u = command END
-      { { Ast.Triple.p; q; ws; f; ps; u } }
+  | PROCEDURE f = VAR LPAREN ps = variable_list RPAREN EQ REQUIRES LBRACE p = logic_expr RBRACE ENSURES LBRACE q = logic_expr RBRACE variant = variant_opt WRITES LBRACE ws = variable_list RBRACE u = command END
+      { { Ast.Triple.p; q; variant; ws; f; ps; u } }
+;
+variant_opt:
+  |
+      { None }
+  | VARIANT LBRACE m = arith_expr RBRACE
+      { Some m }
 ;
 variable_list:
   | p = VAR COMMA ps = variable_list
@@ -29,7 +36,7 @@ variable_list:
 ;
 main:
   | LBRACE p = logic_expr RBRACE u = command LBRACE q = logic_expr RBRACE
-      { { Ast.Triple.p; q; ws = []; f="main"; ps=[]; u } }
+      { { Ast.Triple.p; q; variant = None; ws = []; f="main"; ps=[]; u } }
 ;
 command:
   | v = VAR ASSGN ARRAY LPAREN n = expr RPAREN

--- a/src/ast/triple.ml
+++ b/src/ast/triple.ml
@@ -3,6 +3,7 @@ open Sexplib.Std
 type ut_t = {
   p : Logic.expr; (* Precondition *)
   q : Logic.expr; (* Postcondition *)
+  variant : Logic.arith_expr option; (* Optional termination measure *)
   ws : string list; (* Written global variables *)
   f : string; (* Procedure name *)
   ps : string list; (* Formal parameters *)
@@ -13,6 +14,7 @@ type ut_t = {
 type t = {
   p : Logic.expr; (* Precondition *)
   q : Logic.expr; (* Postcondition *)
+  variant : Logic.arith_expr option; (* Optional termination measure *)
   ws : string list; (* Written global variables *)
   f : string; (* Procedure name *)
   ps : string list; (* Formal parameters *)
@@ -20,5 +22,5 @@ type t = {
 }
 [@@deriving sexp_of]
 
-let translate { p; f; ws; ps; u; q } =
-  { p; f; ws; ps; c = Program.translate_cmd u; q }
+let translate { p; f; variant; ws; ps; u; q } =
+  { p; f; variant; ws; ps; c = Program.translate_cmd u; q }

--- a/src/ast/var_collection.ml
+++ b/src/ast/var_collection.ml
@@ -153,6 +153,15 @@ let arrays_program c =
   in
   cmd c
 
+(* Every variable a procedure declares in [writes] is a global it mutates, so it
+   must be classified as a global even if it never appears in [main]. Otherwise
+   it would be misfiled as a procedure-local and a caller's havoc (which resolves
+   [writes] against the globals) would fail to find it. *)
+let all_writes (program : Triple.t list) =
+  List.fold_left
+    (fun s (t : Triple.t) -> List.fold_left (fun s w -> Str_set.add w s) s t.ws)
+    Str_set.empty program
+
 let all_arrays (program : Triple.t list) =
   List.fold_left
     (fun s (t : Triple.t) ->
@@ -186,7 +195,9 @@ let str_set_to_vars ~arrays vars =
 let collect (program : Triple.t list) =
   let procedures, main = split_last program in
   let arrays = all_arrays program in
-  let globals = collect_procedure Str_set.empty main in
+  let globals =
+    Str_set.union (collect_procedure Str_set.empty main) (all_writes program)
+  in
   let procedures =
     List.map
       (fun proc ->

--- a/src/ast/var_collection.ml
+++ b/src/ast/var_collection.ml
@@ -157,15 +157,17 @@ let all_arrays (program : Triple.t list) =
   List.fold_left
     (fun s (t : Triple.t) ->
       Str_set.union s
-        (Str_set.union (arrays_logic t.p)
-           (Str_set.union (arrays_logic t.q) (arrays_program t.c))))
+        (Str_set.union (arrays_measure t.variant)
+           (Str_set.union (arrays_logic t.p)
+              (Str_set.union (arrays_logic t.q) (arrays_program t.c)))))
     Str_set.empty program
 
 let collect_procedure globals (t : Triple.t) =
   let p_vars = collect_logic t.p in
   let q_vars = collect_logic t.q in
   let c_vars = collect_program t.c in
-  let vars = Str_set.(union p_vars (union q_vars c_vars)) in
+  let v_vars = collect_measure t.variant in
+  let vars = Str_set.(union v_vars (union p_vars (union q_vars c_vars))) in
   (* If global variables occur in the procedure, don't add them as local variables *)
   Str_set.fold (fun global vars -> Str_set.remove global vars) globals vars
 

--- a/src/compile.ml
+++ b/src/compile.ml
@@ -261,7 +261,9 @@ let emit_proc ~ops ((t : Triple.t), _vars) : string =
     match t.ps with [] -> "()" | ps -> List.map lname ps |> String.concat " "
   in
   let locals = Str_set.of_list t.ps in
-  Printf.sprintf "let %s %s =\n%s" (pname t.f) params
+  (* [let rec] so a self-recursive procedure can call itself. (Mutual recursion
+     would additionally need [... and ...]; it is not supported.) *)
+  Printf.sprintf "let rec %s %s =\n%s" (pname t.f) params
     (emit_cmd ~ops ~locals t.c)
 
 let emit ?(native_int = false) (program : (Triple.t * Vars.t) list) : string =

--- a/src/hoare.ml
+++ b/src/hoare.ml
@@ -230,8 +230,12 @@ module Wlp = struct
     (* p_f[x_i <- e_i] /\ forall y. (q_f[x_i <- e_i][x_i <- y_i][x_i@old <- x_i] -> q[x_i <- y_i]) *)
     T.(t_and pre q_sub)
 
-  let rec cmd procs ~machine_int ~g_vars ~l_vars c q =
-    let cmd = cmd procs ~machine_int ~g_vars ~l_vars in
+  (* [self] identifies the procedure whose body is being verified: its name and
+     optional variant. A call back to that name is recursive; if the procedure
+     declares a variant it must strictly decrease across the call (see the [Proc]
+     case). *)
+  let rec cmd procs ~machine_int ~self ~g_vars ~l_vars c q =
+    let cmd = cmd procs ~machine_int ~self ~g_vars ~l_vars in
     (* Well-definedness obligations for an expression evaluated by [c]. The
        divisor-non-zero part ([defined]) is always imposed; the overflow-freedom
        part ([safe]) only in machine-integer mode. In the default (unbounded,
@@ -290,8 +294,33 @@ module Wlp = struct
           List.fold_left (fun acc e -> T.t_and_simp acc (safe_e e)) T.t_true ps
         in
         let triple, callee_l_vars = Proc_map.find f procs in
-        T.t_and_simp args_safe
-          (proc ~machine_int g_vars q callee_l_vars ps triple)
+        (* Termination of recursion: if this call targets the enclosing
+           procedure and it declares a variant [V], the measure at the actual
+           arguments must be non-negative and strictly below its value at the
+           enclosing formals -- [0 <= V[e_i] < V[x_i]]. This is the variant rule
+           applied across a recursive call instead of a loop back-edge. Without a
+           variant the recursion is only checked for partial correctness. *)
+        let decrease =
+          match self with
+          | self_name, Some measure when String.equal f self_name ->
+              let v_formals =
+                Logic.translate_arith_term ~g_vars ~l_vars measure
+              in
+              let sub =
+                List.map2
+                  (fun fp e ->
+                    (Vars.find fp callee_l_vars, expr_to_term ~g_vars ~l_vars e))
+                  triple.Triple.ps ps
+              in
+              let v_actuals = T.t_subst (T.Mvs.of_list sub) v_formals in
+              T.t_and
+                (Arith.leq (T.t_nat_const 0) v_actuals)
+                (Arith.lt v_actuals v_formals)
+          | _ -> T.t_true
+        in
+        T.t_and_simp decrease
+          (T.t_and_simp args_safe
+             (proc ~machine_int g_vars q callee_l_vars ps triple))
     | If (b, c, c') ->
         (* safe(b) /\ ( b -> wlp(c, q) ) /\ ( ~b -> wlp(c', q) ) *)
         let t = expr_to_term ~g_vars ~l_vars b in
@@ -367,7 +396,7 @@ let verify_procedure ?timeout ~machine_int ~is_main g_vars procs
   let p_gen =
     Wlp.(
       sub_old_vars ~g_vars ~l_vars t.ws
-      @@ cmd procs ~machine_int ~g_vars ~l_vars t.c q)
+      @@ cmd procs ~machine_int ~self:(t.f, t.variant) ~g_vars ~l_vars t.c q)
   in
   let merged_vars =
     List.fold_left merge_in (Vars.union l_vars g_vars) t.ps |> list_of_var_map
@@ -417,13 +446,18 @@ let verify ?debug:d ?timeout ?(machine_int = false) program =
   let procs, (main, globals) = split_last program in
   let f ~is_main procs proc =
     let (t : Triple.t) = fst proc in
+    (* Register the procedure in [procs] *before* verifying its body, so a
+       self-recursive call resolves to its own contract (the inductive
+       hypothesis). This lifts the earlier bottom-up ordering restriction. main
+       is never a callee, so it is not registered. *)
+    let procs = if is_main then procs else Proc_map.add t.f proc procs in
     let result =
       if (not is_main) && not (writes_are_declared globals procs t) then
         Smt.Prover.Invalid
       else verify_procedure ?timeout ~machine_int ~is_main globals procs proc
     in
     match result with
-    | Valid -> Proc_map.add t.f proc procs
+    | Valid -> procs
     | Invalid | Failed _ -> raise (Proc_invalid t.f)
   in
   try

--- a/src/main.ml
+++ b/src/main.ml
@@ -9,10 +9,7 @@ let get_ast path =
   let lexbuf = Lexing.from_channel file in
   let ut_ast = Parser.top Lexer.main lexbuf in
   In_channel.close file;
-  let f { Triple.p; q; ws; f; ps; u } =
-    { Triple.p; q; ws; f; ps; c = Program.translate_cmd u }
-  in
-  List.map f ut_ast |> Var_collection.collect
+  List.map Triple.translate ut_ast |> Var_collection.collect
 
 let verify = Hoare.verify
 

--- a/test/bounded.ml
+++ b/test/bounded.ml
@@ -71,3 +71,14 @@ let%test_unit "machine-int: arrays verify" =
     (is_valid (verify "verify_true_array_machine_int.cav"));
   [%test_result: bool] ~expect:true
     (is_valid (verify ~machine_int:true "verify_true_array_machine_int.cav"))
+
+(* Recursion coexists with machine-int mode: a bounded recursive procedure
+   ([0 <= n <= 100]) never overflows in its argument, measure, or writes, so the
+   overflow obligations at the recursive call and in its body discharge. Valid
+   under both models. *)
+let%test_unit "machine-int: recursion verifies" =
+  [%test_result: bool] ~expect:true
+    (is_valid (verify "verify_true_recursion_machine_int.cav"));
+  [%test_result: bool] ~expect:true
+    (is_valid
+       (verify ~machine_int:true "verify_true_recursion_machine_int.cav"))

--- a/test/compile.ml
+++ b/test/compile.ml
@@ -5,7 +5,7 @@ open Ast.Program
 (* Build a [(Triple.t * Vars.t) list] the way [Main.get_ast] would, from a
    hand-written [main] body, and emit OCaml for it. *)
 let triple ?(f = "main") ?(ps = []) ?(ws = []) (c : cmd) : Triple.t =
-  { p = Logic.Bool true; q = Logic.Bool true; ws; f; ps; c }
+  { p = Logic.Bool true; q = Logic.Bool true; variant = None; ws; f; ps; c }
 
 let emit_main (c : cmd) : string =
   Var_collection.collect [ triple c ] |> Cavalry.Compile.emit
@@ -97,7 +97,7 @@ let%test_unit "Compile.emit - procedure: formals are locals, Assgn hits global"
   let out = Var_collection.collect [ proc; main ] |> Cavalry.Compile.emit in
   List.iter
     [
-      "let p_f l_a =";
+      "let rec p_f l_a =";
       (* formal [a] read as a local *)
       "l_a";
       (* the [<-] target is the shared global, not the formal *)
@@ -113,7 +113,7 @@ let%test_unit "Compile.emit - zero-arg procedure takes unit" =
   let proc = triple ~f:"f" (Assgn ("y", Value (Int 1))) in
   let main = triple (Proc ("f", [])) in
   let out = Var_collection.collect [ proc; main ] |> Cavalry.Compile.emit in
-  List.iter [ "let p_f () ="; "(p_f ())" ] ~f:(fun substring ->
+  List.iter [ "let rec p_f () ="; "(p_f ())" ] ~f:(fun substring ->
       [%test_pred: string] (contains ~substring) out)
 
 let%test_unit "Compile.emit - arrays: array ref, make, and indexed get/set" =
@@ -194,6 +194,8 @@ let%test_unit "Compile e2e - arrays and variants, both backends match interp" =
       "exec_array_len.cav";
       "exec_array_proc.cav";
       "exec_variant.cav";
+      (* a self-recursive procedure -- exercises the [let rec] codegen *)
+      "verify_true_recursion.cav";
     ] ~f:(fun fixture ->
       let expect = Int.to_string (Cavalry.Main.exec fixture) in
       [%test_result: string] ~expect (compile_and_run fixture);

--- a/test/dune
+++ b/test/dune
@@ -39,6 +39,8 @@
    verify_true_recursion_partial.cav
    verify_false_recursion_total.cav
    verify_true_writes_global_not_in_main.cav
+   verify_false_recursion_unbounded.cav
+   verify_true_recursion_multi.cav
    verify_false.cav
    verify_false_inv_entry.cav
    verify_false_proc_ensures.cav

--- a/test/dune
+++ b/test/dune
@@ -38,6 +38,7 @@
    verify_false_recursion.cav
    verify_true_recursion_partial.cav
    verify_false_recursion_total.cav
+   verify_true_writes_global_not_in_main.cav
    verify_false.cav
    verify_false_inv_entry.cav
    verify_false_proc_ensures.cav

--- a/test/dune
+++ b/test/dune
@@ -34,6 +34,10 @@
    verify_false_variant_unbounded.cav
    verify_true_variant_proc.cav
    verify_true_variant_array.cav
+   verify_true_recursion.cav
+   verify_false_recursion.cav
+   verify_true_recursion_partial.cav
+   verify_false_recursion_total.cav
    verify_false.cav
    verify_false_inv_entry.cav
    verify_false_proc_ensures.cav

--- a/test/dune
+++ b/test/dune
@@ -41,6 +41,8 @@
    verify_true_writes_global_not_in_main.cav
    verify_false_recursion_unbounded.cav
    verify_true_recursion_multi.cav
+   verify_true_recursion_array.cav
+   verify_true_recursion_machine_int.cav
    verify_false.cav
    verify_false_inv_entry.cav
    verify_false_proc_ensures.cav

--- a/test/fuzz/fuzz.ml
+++ b/test/fuzz/fuzz.ml
@@ -251,7 +251,8 @@ let build_true_q env =
     (fun x v acc -> Logic.And (acc, Logic.Eq (Logic.Var x, logic_int v)))
     env (Logic.Bool true)
 
-let main_triple ~p ~q ~c : Triple.t = { p; q; ws = []; f = "main"; ps = []; c }
+let main_triple ~p ~q ~c : Triple.t =
+  { p; q; variant = None; ws = []; f = "main"; ps = []; c }
 
 let verify_program (triples : Triple.t list) =
   Hoare.verify ?timeout:(Some verify_timeout) (Var_collection.collect triples)
@@ -321,6 +322,7 @@ let framing_triples (s0, hidden, kh, roles) : Triple.t list =
     {
       p = Logic.Bool true;
       q = Logic.Bool true;
+      variant = None;
       ws = framing_writes roles;
       f = "f";
       ps = [];

--- a/test/integration.ml
+++ b/test/integration.ml
@@ -196,6 +196,11 @@ let%test_unit "Main.verify true recursion (total)" =
 let%test_unit "Main.verify true recursion (partial, vacuous)" =
   check_verify "verify_true_recursion_partial.cav" Valid
 
+(* Two recursive calls in one body ([fib(n-1)] and [fib(n-2)]): each call site
+   gets its own decrease obligation, both discharged in the [n >= 2] branch. *)
+let%test_unit "Main.verify true recursion (multiple calls)" =
+  check_verify "verify_true_recursion_multi.cav" Valid
+
 (* A variant whose measure is array-based ([len(a) - i]): variants compose with
    arrays and the [len]/element machinery. *)
 let%test_unit "Main.verify true variant with array measure" =
@@ -233,6 +238,12 @@ let%test_unit "Main.verify false recursion (variant does not decrease)" =
    total correctness demands termination, which cannot be proved. *)
 let%test_unit "Main.verify false recursion (total)" =
   check_verify "verify_false_recursion_total.cav" Invalid
+
+(* Bounded-below half of the recursion decrease obligation: [dive] recurses on
+   [n - 1] (which decreases) but with no lower bound on [n], so [0 <= n - 1]
+   cannot be proved -- the recursion need not terminate. *)
+let%test_unit "Main.verify false recursion (unbounded below)" =
+  check_verify "verify_false_recursion_unbounded.cav" Invalid
 
 (* Loop invariant that does not hold on entry. *)
 let%test_unit "Main.verify false invariant on entry" =

--- a/test/integration.ml
+++ b/test/integration.ml
@@ -201,6 +201,12 @@ let%test_unit "Main.verify true recursion (partial, vacuous)" =
 let%test_unit "Main.verify true recursion (multiple calls)" =
   check_verify "verify_true_recursion_multi.cav" Valid
 
+(* Recursion over an array: [fill] writes [a\[i\]] and recurses with a
+   [len(a) - i] measure, exercising the array bounds obligation and the array
+   havoc across a recursive call together. *)
+let%test_unit "Main.verify true recursion over an array" =
+  check_verify "verify_true_recursion_array.cav" Valid
+
 (* A variant whose measure is array-based ([len(a) - i]): variants compose with
    arrays and the [len]/element machinery. *)
 let%test_unit "Main.verify true variant with array measure" =

--- a/test/integration.ml
+++ b/test/integration.ml
@@ -26,6 +26,10 @@ let%test_unit "Main.exec procedure call" =
 let%test_unit "Main.exec variant is ignored at runtime" =
   [%test_result: int] (Main.exec "exec_variant.cav") ~expect:10
 
+(* A recursive procedure runs and terminates: sum_to(5) = 0+1+...+5 = 15. *)
+let%test_unit "Main.exec recursion" =
+  [%test_result: int] (Main.exec "verify_true_recursion.cav") ~expect:15
+
 (* Two nested loops each running 3 times -> 9 increments. *)
 let%test_unit "Main.exec nested while" =
   [%test_result: int] (Main.exec "exec_nested_while.cav") ~expect:9
@@ -174,6 +178,18 @@ let%test_unit "Main.verify true non-terminating loop (partial, vacuous)" =
 let%test_unit "Main.verify true variant in procedure" =
   check_verify "verify_true_variant_proc.cav" Valid
 
+(* Total-correctness recursion: [sum_to] calls itself with a decreasing variant
+   [n], verified inductively (its own contract is the hypothesis for the
+   recursive call). Lifts the old bottom-up ordering restriction. *)
+let%test_unit "Main.verify true recursion (total)" =
+  check_verify "verify_true_recursion.cav" Valid
+
+(* Partial correctness allows recursion with no variant: a non-terminating
+   recursive procedure makes [ensures { false }] -- and hence the whole triple --
+   vacuously provable, just like a non-terminating loop. *)
+let%test_unit "Main.verify true recursion (partial, vacuous)" =
+  check_verify "verify_true_recursion_partial.cav" Valid
+
 (* A variant whose measure is array-based ([len(a) - i]): variants compose with
    arrays and the [len]/element machinery. *)
 let%test_unit "Main.verify true variant with array measure" =
@@ -201,6 +217,16 @@ let%test_unit "Main.verify false non-terminating loop (total)" =
    the loop need not terminate and [0 <= V] cannot be proved. *)
 let%test_unit "Main.verify false variant unbounded below" =
   check_verify "verify_false_variant_unbounded.cav" Invalid
+
+(* Recursion with a variant that does not decrease across the recursive call
+   ([loops(n)] recurses on the same [n]) is rejected: [n < n] is false. *)
+let%test_unit "Main.verify false recursion (variant does not decrease)" =
+  check_verify "verify_false_recursion.cav" Invalid
+
+(* The same non-terminating recursion as the partial fixture, now with a variant:
+   total correctness demands termination, which cannot be proved. *)
+let%test_unit "Main.verify false recursion (total)" =
+  check_verify "verify_false_recursion_total.cav" Invalid
 
 (* Loop invariant that does not hold on entry. *)
 let%test_unit "Main.verify false invariant on entry" =

--- a/test/integration.ml
+++ b/test/integration.ml
@@ -95,6 +95,12 @@ let%test_unit "Main.verify true frame" =
 let%test_unit "Main.verify true read global" =
   check_verify "verify_true_read_global.cav" Valid
 
+(* A procedure may `writes` a global that never appears in `main`: it is still
+   classified as a global (not a procedure-local), so the caller's havoc
+   resolves it. Previously this crashed with [Var_not_found]. *)
+let%test_unit "Main.verify true writes global absent from main" =
+  check_verify "verify_true_writes_global_not_in_main.cav" Valid
+
 (* Assertion operators absent from other fixtures: || , -> , != . *)
 let%test_unit "Main.verify true disjunction" =
   check_verify "verify_true_disjunction.cav" Valid

--- a/test/program.ml
+++ b/test/program.ml
@@ -192,6 +192,7 @@ let%test_unit "Ast.Runtime.exec - function" =
             UAssgn ("x", UPlus (UVar "x", UVar "y")) );
       p = Logic.(Leq (Int 0, Int 0));
       q = Logic.(Leq (Int 0, Int 0));
+      variant = None;
       ws = [];
     }
   in
@@ -207,6 +208,7 @@ let%test_unit "Ast.Runtime.exec - function" =
           );
       p = Logic.(Leq (Int 0, Int 0));
       q = Logic.(Leq (Int 0, Int 0));
+      variant = None;
       ws = [];
     }
   in

--- a/test/verify_false_recursion.cav
+++ b/test/verify_false_recursion.cav
@@ -1,0 +1,13 @@
+procedure loops (n) =
+  requires { n >= 0 }
+  ensures { true }
+  variant { n }
+  writes { r }
+  r <- n;
+  loops(n)
+end
+
+{ true }
+r <- 0;
+loops(3)
+{ 0 <= r }

--- a/test/verify_false_recursion_total.cav
+++ b/test/verify_false_recursion_total.cav
@@ -1,0 +1,13 @@
+procedure loops (n) =
+  requires { true }
+  ensures { false }
+  variant { n }
+  writes { r }
+  r <- 0;
+  loops(n)
+end
+
+{ true }
+r <- 0;
+loops(3)
+{ false }

--- a/test/verify_false_recursion_unbounded.cav
+++ b/test/verify_false_recursion_unbounded.cav
@@ -1,0 +1,12 @@
+procedure dive (n) =
+  requires { true }
+  ensures { true }
+  variant { n }
+  writes { r }
+  r <- n;
+  dive(n - 1)
+end
+
+{ true }
+dive(3)
+{ true }

--- a/test/verify_true_recursion.cav
+++ b/test/verify_true_recursion.cav
@@ -1,0 +1,16 @@
+procedure sum_to (n) =
+  requires { n >= 0 }
+  ensures { s >= 0 }
+  variant { n }
+  writes { s }
+  if n = 0 then
+    s <- 0
+  else
+    sum_to(n - 1);
+    s <- s + n
+  end
+end
+
+{ true }
+sum_to(5)
+{ s >= 0 }

--- a/test/verify_true_recursion_array.cav
+++ b/test/verify_true_recursion_array.cav
@@ -1,0 +1,17 @@
+procedure fill (i) =
+  requires { 0 <= i && i <= len(a) }
+  ensures { true }
+  variant { len(a) - i }
+  writes { a }
+  if i < len(a) then
+    a[i] <- 0;
+    fill(i + 1)
+  else
+    0
+  end
+end
+
+{ true }
+a <- array(3);
+fill(0)
+{ true }

--- a/test/verify_true_recursion_machine_int.cav
+++ b/test/verify_true_recursion_machine_int.cav
@@ -1,0 +1,17 @@
+procedure count (n) =
+  requires { 0 <= n && n <= 100 }
+  ensures { true }
+  variant { n }
+  writes { r }
+  if n = 0 then
+    r <- 0
+  else
+    r <- n;
+    count(n - 1)
+  end
+end
+
+{ true }
+r <- 0;
+count(10)
+{ true }

--- a/test/verify_true_recursion_multi.cav
+++ b/test/verify_true_recursion_multi.cav
@@ -1,0 +1,17 @@
+procedure fib (n) =
+  requires { n >= 0 }
+  ensures { r >= 0 }
+  variant { n }
+  writes { r }
+  if n < 2 then
+    r <- n
+  else
+    fib(n - 1);
+    fib(n - 2)
+  end
+end
+
+{ true }
+r <- 0;
+fib(6)
+{ 0 <= r }

--- a/test/verify_true_recursion_partial.cav
+++ b/test/verify_true_recursion_partial.cav
@@ -1,0 +1,12 @@
+procedure loops (n) =
+  requires { true }
+  ensures { false }
+  writes { r }
+  r <- 0;
+  loops(n)
+end
+
+{ true }
+r <- 0;
+loops(3)
+{ false }

--- a/test/verify_true_writes_global_not_in_main.cav
+++ b/test/verify_true_writes_global_not_in_main.cav
@@ -1,0 +1,10 @@
+procedure init () =
+  requires { true }
+  ensures { g = 0 }
+  writes { g }
+  g <- 0
+end
+
+{ true }
+init()
+{ true }


### PR DESCRIPTION
## Summary

Procedures may now call themselves. This is the final roadmap step (div/mod → arrays+quantifiers → variants → **recursion**), and it builds directly on the loop-variant machinery from PR #7.

## The change

Previously procedures had to be defined bottom-up (a call resolved a callee already in the `Proc_map`), so self-calls were impossible. Now `verify` registers a procedure's **contract** in the map *before* verifying its body, so a self-call resolves to that contract — the inductive hypothesis. This lifts the ordering restriction.

**Soundness follows the variant rule, one level up.** Procedures gain an optional `variant { measure }` clause (over their parameters). At a recursive call site the WLP emits:

```
0 <= V[actuals] < V[formals]
```

— the measure is non-negative and strictly smaller at the recursive call than at the current invocation. That is exactly the loop-variant obligation (`0 <= V` bounded-below + strict decrease), applied across a call instead of a loop back-edge, giving **total** correctness. Without a variant, recursion is still allowed but only checked for **partial** correctness (a non-terminating recursion vacuously satisfies any postcondition, just like a non-terminating loop).

The measure is verification-only. The interpreter already registered all procedures before running, so recursion worked there; the compiler now emits `let rec` per procedure so a self-call resolves.

## Scope

**Self-recursion only.** Mutual recursion (recursive *groups*, needing call-graph SCC detection and `let rec … and`) is deferred as a follow-up.

## Also included: a root-cause fix

While testing I hit a pre-existing crash: a procedure that `writes` a global never mentioned in `main` had that variable misclassified as procedure-local, and a caller's havoc raised an uncaught `Var_not_found`. Fixed at the root — every `writes` variable is now folded into the global set (`07b64c6`). Idempotent for existing programs, so no behaviour change; added a regression fixture.

## Testing

Green across `dune runtest` (inline + fuzzer) and `dune build @fmt`; existing non-recursive procedures are unaffected (the bottom-up path still works).

Verification fixtures:
- total-correctness recursion (`sum_to`, proved inductively with `ensures { s >= 0 }`);
- **both halves** of the recursion decrease obligation rejected: non-decreasing (`n < n`) and unbounded-below (`0 <= n-1` unprovable);
- the partial-vs-total pair: a non-terminating recursion verifies vacuously with no variant but is rejected with one;
- multiple recursive calls in one body (fib-style — each call site gets its own obligation);
- **arrays × recursion** (`fill` recurses over an array: index bounds + array havoc across the call + a `len(a)` measure);
- **machine-int × recursion** (bounded recursion valid under both integer models).

Interpreter + both compile backends run a recursive procedure (`let rec` codegen).

## Known follow-ups (not in this PR)

- Mutual recursion.
- The soundness fuzzer generates neither recursion nor variants/arrays (its pin-concrete-state strategy is a poor fit for verification-only features); tracked separately.