### PR TITLE
Syntax highlighting and // line comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,6 @@ _opam/
 # direnv cache
 .direnv/
 
-.vscode
+.vscode/*
+!.vscode/settings.json
 PLAN.md

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "editor.tokenColorCustomizations": {
+    "textMateRules": [
+      {
+        "scope": "keyword.other.specification.cavalry",
+        "settings": { "fontStyle": "italic" }
+      }
+    ]
+  }
+}

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,0 +1,26 @@
+# Cavalry syntax highlighting
+
+A minimal VS Code extension providing a TextMate grammar for `.cav` files.
+The grammar (`syntaxes/cavalry.tmLanguage.json`, scope `source.cavalry`) is a
+plain TextMate grammar, so it is also consumable by Sublime Text, the
+`vscode-textmate` library, and — if the language is registered upstream —
+GitHub Linguist.
+
+## Try it locally
+
+```bash
+# From the repository root, symlink the extension into VS Code, then reload:
+ln -s "$PWD/editors/vscode" ~/.vscode/extensions/cavalry
+```
+
+Open any `.cav` file (e.g. `example.cav`) and highlighting is applied by file
+extension. Use the *Developer: Inspect Editor Tokens and Scopes* command to see
+the scope assigned to the token under the cursor.
+
+## Packaging
+
+```bash
+npm install -g @vscode/vsce
+cd editors/vscode
+vsce package        # produces cavalry-0.1.0.vsix
+```

--- a/editors/vscode/language-configuration.json
+++ b/editors/vscode/language-configuration.json
@@ -1,0 +1,20 @@
+{
+  "comments": {
+    "lineComment": "//"
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" }
+  ],
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ]
+}

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "cavalry",
+  "displayName": "Cavalry",
+  "description": "Syntax highlighting for the Cavalry verification language",
+  "version": "0.1.0",
+  "publisher": "benmandrew",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/benmandrew/cavalry"
+  },
+  "engines": {
+    "vscode": "^1.60.0"
+  },
+  "categories": ["Programming Languages"],
+  "contributes": {
+    "languages": [
+      {
+        "id": "cavalry",
+        "aliases": ["Cavalry", "cavalry"],
+        "extensions": [".cav"],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "cavalry",
+        "scopeName": "source.cavalry",
+        "path": "./syntaxes/cavalry.tmLanguage.json"
+      }
+    ]
+  }
+}

--- a/editors/vscode/syntaxes/cavalry.tmLanguage.json
+++ b/editors/vscode/syntaxes/cavalry.tmLanguage.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Cavalry",
+  "scopeName": "source.cavalry",
+  "patterns": [
+    { "include": "#comments" },
+    { "include": "#specification" },
+    { "include": "#keywords" },
+    { "include": "#constants" },
+    { "include": "#builtins" },
+    { "include": "#numbers" },
+    { "include": "#operators" },
+    { "include": "#punctuation" },
+    { "include": "#identifiers" }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.double-slash.cavalry",
+          "begin": "//",
+          "end": "$",
+          "beginCaptures": {
+            "0": { "name": "punctuation.definition.comment.cavalry" }
+          }
+        }
+      ]
+    },
+    "specification": {
+      "patterns": [
+        {
+          "name": "keyword.other.specification.cavalry",
+          "match": "\\b(requires|ensures|invariant|variant|writes)\\b"
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.control.cavalry",
+          "match": "\\b(if|then|else|while|do|end)\\b"
+        },
+        {
+          "name": "keyword.other.cavalry",
+          "match": "\\b(procedure|print)\\b"
+        }
+      ]
+    },
+    "constants": {
+      "patterns": [
+        {
+          "name": "constant.language.boolean.cavalry",
+          "match": "\\b(true|false)\\b"
+        }
+      ]
+    },
+    "builtins": {
+      "patterns": [
+        {
+          "name": "support.function.builtin.cavalry",
+          "match": "\\b(len|array)\\b"
+        },
+        {
+          "name": "keyword.other.quantifier.cavalry",
+          "match": "\\b(forall|exists)\\b"
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.integer.cavalry",
+          "match": "\\b[0-9]+\\b"
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.assignment.cavalry",
+          "match": "<-"
+        },
+        {
+          "name": "keyword.operator.logical.cavalry",
+          "match": "->|&&|\\|\\||!"
+        },
+        {
+          "name": "keyword.operator.comparison.cavalry",
+          "match": "<=|>=|!=|<|>|="
+        },
+        {
+          "name": "keyword.operator.arithmetic.cavalry",
+          "match": "[-+*/%]"
+        }
+      ]
+    },
+    "punctuation": {
+      "patterns": [
+        {
+          "name": "punctuation.terminator.statement.cavalry",
+          "match": ";"
+        },
+        {
+          "name": "punctuation.separator.cavalry",
+          "match": "[.,]"
+        }
+      ]
+    },
+    "identifiers": {
+      "patterns": [
+        {
+          "name": "variable.other.cavalry",
+          "match": "[A-Za-z_]+"
+        }
+      ]
+    }
+  }
+}

--- a/example.cav
+++ b/example.cav
@@ -1,3 +1,4 @@
+// Compute q = x / y and r = x % y by repeated subtraction.
 procedure euclidean_div () =
   requires { x >= 0 }
   ensures { x = q * y + r && 0 <= r && r < y }
@@ -5,7 +6,7 @@ procedure euclidean_div () =
   q <- 0;
   r <- x;
   while r >= y do
-    invariant { x = q * y + r && 0 <= r }
+    invariant { x = q * y + r && 0 <= r } // loop invariant, proved on every iteration
     r <- r - y;
     q <- q + 1
   end
@@ -19,4 +20,4 @@ r <- 0;
 euclidean_div();
 print(q);
 print(r)
-{ q = 2 && r = 8 }
+{ q = 2 && r = 8 } // 42 = 2 * 17 + 8

--- a/src/ast/parse/lexer.mll
+++ b/src/ast/parse/lexer.mll
@@ -9,6 +9,8 @@ exception Error of error
 rule main = parse
   | [' ' '\t' '\n']
       { main lexbuf }
+  | "//"
+      { comment lexbuf }
   | ['0'-'9']+ as i
       { INT (int_of_string i) }
   | "true"
@@ -107,3 +109,12 @@ rule main = parse
     { raise
         (Error
           (Illegal_character illegal_char)) }
+
+(* A [//] line comment runs to the next newline (or eof). *)
+and comment = parse
+  | '\n'
+      { main lexbuf }
+  | eof
+      { EOF }
+  | _
+      { comment lexbuf }

--- a/test/dune
+++ b/test/dune
@@ -4,6 +4,7 @@
  (inline_tests
   (deps
    exec_if.cav
+   exec_comment.cav
    exec_while.cav
    exec_proc.cav
    exec_nested_while.cav

--- a/test/exec_comment.cav
+++ b/test/exec_comment.cav
@@ -1,0 +1,11 @@
+// a leading comment
+{ true }
+x <- 2; // trailing comment after a statement
+// a comment on its own line
+y <- 60;
+if x + 3 = 5 then
+  x + y * 3 // 2 + 60 * 3 = 182
+else
+  9
+end
+{ true }

--- a/test/integration.ml
+++ b/test/integration.ml
@@ -14,6 +14,11 @@ let check_verify path expect =
 let%test_unit "Main.exec if" =
   [%test_result: int] (Main.exec "exec_if.cav") ~expect:182
 
+(* [//] line comments are stripped by the lexer, so a program peppered with
+   them evaluates identically to exec_if.cav: 2 + 60 * 3 = 182. *)
+let%test_unit "Main.exec line comments" =
+  [%test_result: int] (Main.exec "exec_comment.cav") ~expect:182
+
 let%test_unit "Main.exec while" =
   [%test_result: int] (Main.exec "exec_while.cav") ~expect:45
 


### PR DESCRIPTION
## What

Add syntax highlighting for Cavalry, and the `//` line comments that highlighting needs a scope for.

## Changes

- **`//` line comments** — a new `comment` rule in `src/ast/parse/lexer.mll` discards from `//` through the next newline (or eof), matching the C/OCaml convention. Covered by `test/exec_comment.cav` (comments in leading, trailing, and own-line positions) asserting the same result as the equivalent comment-free program.
- **TextMate grammar / VS Code extension** — `editors/vscode/` colourises `.cav` files (scope `source.cavalry`). Being a plain TextMate grammar, it also works with Sublime Text, `vscode-textmate`, and GitHub Linguist once the language is registered upstream. Token scopes follow the lexer; the Hoare-specification keywords (`requires`/`ensures`/`invariant`/`variant`/`writes`) get a distinct `keyword.other.specification` scope so annotations can be themed apart from executable code.
- **`example.cav`** — annotated with `//` comments to demonstrate the new syntax.
- **`.vscode/settings.json`** — italicises the spec-keyword scope using `fontStyle` only (no `foreground`), so the distinction holds in both light and dark themes regardless of theme name. `.gitignore` narrowed to track just this shared file.

## Testing

- `dune build`, `dune runtest`, `dune build @fmt` all pass.
- `dune exec -- cav verify example.cav` still succeeds with the comments added.
- The grammar was validated by JSON parse and by construction (operator alternatives ordered longest-first so `<-`/`->` win over `<`/`-`); it was **not** run through a live tokenizer, as that needs `vscode-textmate` + oniguruma which weren't available in the dev environment.
