### PR TITLE
Document the public interface and generate HTML docs with odoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           key: opam-switch-v1-${{ matrix.ocaml-compiler }}-${{ hashFiles('cavalry.opam') }}
 
       - name: Install dependencies
-        run: opam install . --deps-only --with-test
+        run: opam install . --deps-only --with-test --with-doc
 
       - name: Detect why3 provers
         run: opam exec -- why3 config detect
@@ -58,6 +58,9 @@ jobs:
 
       - name: Run tests
         run: opam exec -- dune build @runtest
+
+      - name: Build docs
+        run: opam exec -- dune build @doc
 
       # zanuda is a typedtree-based linter tightly coupled to the OCaml
       # compiler; its releases don't support 5.5.0, so this runs only on the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,13 +13,14 @@ article linked from `README.md` for the theory.
 ## Commands
 
 ```bash
-opam install --deps-only --with-test .   # install deps (incl. why3, alt-ergo 2.4.3)
+opam install --deps-only --with-test --with-doc .   # install deps (incl. why3, alt-ergo 2.4.3, odoc)
 why3 config detect                       # required once, so why3 can find alt-ergo
 
 dune build                               # build everything
 dune build @fmt                          # check formatting (ocamlformat)
 dune build @fmt --auto-promote           # apply formatting fixes
 dune runtest                             # run the inline-test suite (test/)
+dune build @doc                          # generate HTML API docs to _build/default/_doc/_html/
 
 dune exec -- cav run <file.cav>            # interpret a program
 dune exec -- cav verify <file.cav>         # verify pre/post conditions
@@ -29,7 +30,8 @@ dune exec -- cav verify -d <file.cav>      # verify with debug output (prints WL
 There's no per-test filter wired up; `dune runtest` runs the whole
 `test/integration.ml` + `test/program.ml` suite together against the `.cav`
 fixtures in `test/`. CI (`.github/workflows/`) runs `why3 config detect`,
-`dune build @fmt`, `dune build`, and `dune build @runtest` on ocaml 5.5.0.
+`dune build @fmt`, `dune build`, `dune build @runtest`, and `dune build @doc`
+on ocaml 5.5.0.
 
 ## Architecture
 

--- a/cavalry.opam
+++ b/cavalry.opam
@@ -20,8 +20,8 @@ depends: [
   "zarith"
   "ppx_deriving"
   "qcheck-core" {with-test}
-  "ocamlformat" {= "0.29.0" & with-test}
   "odoc" {with-doc}
+  "ocamlformat" {= "0.29.0" & with-test}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/doc/dune
+++ b/doc/dune
@@ -1,0 +1,2 @@
+(documentation
+ (package cavalry))

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -1,0 +1,48 @@
+{0 Cavalry}
+
+Cavalry is a toy imperative language with Hoare-logic verification. A program
+carries its own specification -- preconditions, postconditions, and loop
+invariants -- and is proven to meet it by a {e satisfiability-modulo-theories}
+(SMT) solver, Alt-Ergo, driven through Why3. Nothing is executed to establish
+correctness; the proof is discharged over the program text.
+
+The surface syntax is shown in [example.cav]; the theory is described in the
+article linked from the {{:https://github.com/benmandrew/cavalry}repository}.
+
+{1 Pipeline}
+
+Both [cav run] and [cav verify] share a front end and split at the final step.
+The stages, in order:
+
+- {b Parse} ({!Parse}) turns source into an {e untyped} AST -- [Ast.Program.ut_expr]
+  wrapped in [Ast.Triple.ut_t].
+- {b Type and translate} ({!Ast.Program}) resolves that into the GADT-typed
+  {!Ast.Program.cmd}, rejecting ill-typed programs with {!Ast.Program.TypeError}.
+- {b Resolve variables} ({!Ast.Var_collection}) assigns every program variable a
+  Why3 symbol, splitting per-procedure locals from [main]'s globals.
+- {b Run or verify.} {!Ast.Runtime} is the tree-walking interpreter behind
+  [cav run]; {!Cavalry.Hoare} is the weakest-liberal-precondition calculus
+  behind [cav verify], which compiles each triple to a Why3 goal and discharges
+  it through {!Smt.Prover}.
+
+{1 Modules}
+
+{2 Front end}
+
+- {!Ast.Program} -- the executable program AST, untyped and GADT-typed.
+- {!Ast.Logic} -- the assertion language of the annotations.
+- {!Ast.Triple} -- one Hoare triple [{p} c {q}] per procedure.
+- {!Parse} -- the ocamllex/Menhir lexer and grammar.
+
+{2 Verification}
+
+- {!Cavalry.Hoare} -- the WLP calculus and top-level [verify].
+- {!Ast.Arith} -- the Why3 encoding of the integer and array theory.
+- {!Smt.Prover} -- the Why3/Alt-Ergo backend.
+
+{2 Support}
+
+- {!Ast.Vars} -- the name-to-symbol environment.
+- {!Ast.Var_collection} -- building those environments from a program.
+- {!Ast.Runtime} -- the interpreter.
+- {!Cavalry.Main} -- the library entry points the [cav] CLI wraps.

--- a/dune-project
+++ b/dune-project
@@ -28,6 +28,7 @@
   zarith
   ppx_deriving
   (qcheck-core :with-test)
+  (odoc :with-doc)
   (ocamlformat
    (and
     (= "0.29.0")

--- a/src/ast/arith.mli
+++ b/src/ast/arith.mli
@@ -1,8 +1,20 @@
+(** The Why3 encoding of Cavalry's integer and array theory: term constructors
+    for every arithmetic and comparison operator, the machine-int bounds used
+    for overflow reasoning, and the proof-task builders that pull in the right
+    background theories for a given goal.
+
+    Everything downstream ([Logic.translate_term], [Hoare]) compiles source
+    expressions into Why3 [Term.term]s through these combinators. *)
+
 open Why3
 
 val plus : Term.term -> Term.term -> Term.term
 val sub : Term.term -> Term.term -> Term.term
+
 val mul : Term.term -> Term.term -> Term.term
+(** [plus]/[sub]/[mul] build the integer [+]/[-]/[*] application terms over
+    Why3's unbounded [int] theory. Overflow, when it matters, is a separate
+    obligation ([Hoare.safe]) rather than a property of these terms. *)
 
 val div : Term.term -> Term.term -> Term.term
 (** Truncated (round-towards-zero) integer division, matching OCaml's native
@@ -32,7 +44,10 @@ val neq : Term.term -> Term.term -> Term.term
 val lt : Term.term -> Term.term -> Term.term
 val leq : Term.term -> Term.term -> Term.term
 val gt : Term.term -> Term.term -> Term.term
+
 val geq : Term.term -> Term.term -> Term.term
+(** The six integer comparison predicates ([=], [<>], [<], [<=], [>], [>=]),
+    each building a proposition term from two integer terms. *)
 
 val min_int : Term.term
 (** The smallest representable machine integer, [-2^62] (OCaml 63-bit [int]). *)
@@ -46,6 +61,9 @@ val in_bounds : Term.term -> Term.term
 *)
 
 val base_task : Task.task
+(** The proof task seeded with only the base integer theory, before any
+    goal-specific theories ([ComputerDivision], maps) are layered on. Prefer
+    {!task_for}, which selects those automatically. *)
 
 val task_for : Term.term -> Task.task
 (** The proof task to discharge a goal against: the integer theory, plus Why3's

--- a/src/ast/dune
+++ b/src/ast/dune
@@ -1,5 +1,6 @@
 (library
  (name ast)
+ (public_name cavalry.ast)
  (libraries core why3 smt astring)
  (preprocess
   (pps ppx_jane ppx_deriving.show)))

--- a/src/ast/logic.mli
+++ b/src/ast/logic.mli
@@ -1,6 +1,18 @@
+(** The assertion language: the AST of the logical annotations a program carries
+    -- preconditions, postconditions, loop invariants and variants -- together
+    with its translation into Why3 terms for the prover.
+
+    Unlike {!Program}'s expressions these are untyped (a flat [arith_expr] /
+    [logic_expr] split rather than a GADT), since assertions are parsed
+    separately and never interpreted, only translated. *)
+
 module T = Why3.Term
 
 (* Untyped AST to play nice with the Menhir parser generator *)
+
+(** Integer-valued assertion terms: literals, program/quantifier variables,
+    arithmetic, and the array projections [Get] ([a[i]]) and [Len] ([len(a)]).
+*)
 type arith_expr =
   | Int of int
   | Var of string
@@ -13,6 +25,8 @@ type arith_expr =
   | Len of string
 [@@deriving sexp_of, show]
 
+(** Proposition-valued assertion terms: a first-order logic over the
+    {!arith_expr} comparisons, closed under the connectives and quantifiers. *)
 type logic_expr =
   | Bool of bool
   | Not of logic_expr
@@ -30,6 +44,7 @@ type logic_expr =
 [@@deriving sexp_of, show]
 
 type expr = logic_expr [@@deriving sexp_of, show]
+(** The top-level assertion form -- a proposition. Alias for {!logic_expr}. *)
 
 val translate_arith_term :
   g_vars:Vars.t -> ?l_vars:Vars.t -> ?bound:Vars.t -> arith_expr -> T.term
@@ -38,6 +53,13 @@ val translate_arith_term :
 
 val translate_term :
   g_vars:Vars.t -> ?l_vars:Vars.t -> ?bound:Vars.t -> expr -> T.term
+(** Translate a proposition to a Why3 term. Names resolve against [g_vars], then
+    the optional procedure-locals [l_vars]; quantifier-bound names ([bound],
+    extended as [Forall]/[Exists] are entered) shadow both. *)
 
 val print_expr : expr -> unit
+(** Print an assertion's AST as an s-expression to stdout. For [-d] debug
+    output. *)
+
 val print_term : T.term -> unit
+(** Pretty-print a translated Why3 term to stdout. For [-d] debug output. *)

--- a/src/ast/parse/dune
+++ b/src/ast/parse/dune
@@ -1,5 +1,6 @@
 (library
  (name parse)
+ (public_name cavalry.parse)
  (libraries ast))
 
 (ocamllex

--- a/src/ast/program.mli
+++ b/src/ast/program.mli
@@ -1,3 +1,14 @@
+(** The executable program AST, in both of its forms: the untyped {!ut_expr} the
+    parser produces, and the GADT-typed {!value}/{!expr}/{!cmd} that
+    {!translate_cmd} type-checks it into. The typed AST is the shared input to
+    both consumers -- {!Runtime}'s interpreter and [Hoare]'s WLP calculus.
+
+    Program {e assertions} live separately in {!Logic}; this module is the code
+    that runs. *)
+
+(** Leaf values, GADT-indexed by their OCaml type. [VarInst] is a variable
+    occurrence (always integer-valued, hence [int value]); it names a binding
+    resolved later against the {!Vars} environment. *)
 type _ value =
   | Unit : unit -> unit value
   | Int : int -> int value
@@ -5,6 +16,9 @@ type _ value =
   | VarInst : string -> int value
 [@@deriving sexp_of]
 
+(** Pure expressions, indexed by result type so the type system rules out
+    ill-typed combinations (e.g. adding a comparison): comparisons yield
+    [bool expr], arithmetic and the array projections yield [int expr]. *)
 type _ expr =
   | Value : 'a value -> 'a expr
   | Eq : int expr * int expr -> bool expr
@@ -22,6 +36,10 @@ type _ expr =
   | Len : string -> int expr
 [@@deriving sexp_of]
 
+(** Commands (statements). [Let] introduces a local binding, [Assgn] mutates an
+    existing variable, [Proc] is a call by name. [While] carries its loop
+    invariant and optional variant (decreasing measure) alongside guard and
+    body. [ArrMake] is [a <- array(n)] and [ArrAssgn] is [a[i] <- e]. *)
 type cmd =
   | IntExpr of int expr
   | Seq of cmd * cmd
@@ -36,6 +54,9 @@ type cmd =
 [@@deriving sexp_of]
 
 (* Untyped AST to play nice with the Menhir parser generator *)
+
+(** The untyped AST the parser emits, with expressions and commands in one flat
+    variant. {!translate_cmd} resolves it into the typed {!cmd}. *)
 type ut_expr =
   | UInt of int
   | UBool of bool
@@ -65,5 +86,12 @@ type ut_expr =
 [@@deriving sexp_of, show]
 
 exception TypeError of string
+(** Raised by {!translate_cmd} on an untyped tree that does not type-check --
+    e.g. a boolean where an integer is required, or an expression used where a
+    command is expected. Carries the offending node, rendered by [show]. *)
 
 val translate_cmd : ut_expr -> cmd
+(** Type-check and translate the untyped parser output into the typed {!cmd}
+    AST.
+
+    @raise TypeError on malformed input. *)

--- a/src/ast/runtime.mli
+++ b/src/ast/runtime.mli
@@ -1,13 +1,26 @@
-type proc_t = { f : string; ps : string list; c : Program.cmd }
+(** The tree-walking interpreter behind [cav run]: it executes the typed
+    {!Program.cmd} AST directly, ignoring the pre/postcondition annotations that
+    [Hoare] consumes. Runs the same procedure list the verifier does, with the
+    last one taken as [main]. *)
 
-(* The final-state environment of a run, keyed by variable name. *)
+type proc_t = { f : string; ps : string list; c : Program.cmd }
+(** A runnable procedure: name [f], formal parameters [ps], and body [c]. The
+    interpreter's stripped-down view of a {!Triple.t} -- the logical annotations
+    are dropped. *)
+
 module Env : Map.S with type key = string
+(** The final-state environment of a run, keyed by variable name. *)
 
 val to_proc_t : Triple.t -> proc_t
-val exec : proc_t list -> int
+(** Project a verified {!Triple.t} down to its runnable {!proc_t}, discarding
+    the pre/postcondition, variant, and [writes] clause. *)
 
-(* Outcome of a fuel-bounded run; [Terminated] carries the final global
-   environment. [OutOfFuel] also covers detected arithmetic overflow. *)
+val exec : proc_t list -> int
+(** Interpret a program -- the procedure list with [main] last -- and return the
+    integer [main] evaluates to. Used by [cav run]. *)
+
+(** Outcome of a fuel-bounded run; [Terminated] carries the final global
+    environment. [OutOfFuel] also covers detected arithmetic overflow. *)
 type exec_result = Terminated of int Env.t | OutOfFuel | Raised
 
 val exec_env : ?fuel:int -> proc_t list -> exec_result

--- a/src/ast/var_collection.mli
+++ b/src/ast/var_collection.mli
@@ -1,1 +1,13 @@
+(** Assigning each program variable its Why3 [vsymbol], the bridge between the
+    parsed AST and everything that reasons over terms ({!Logic}, [Hoare]). *)
+
 val collect : Triple.t list -> (Triple.t * Vars.t) list
+(** Walk the program -- procedures followed by [main] -- and pair each triple
+    with the {!Vars.t} environment its terms resolve against.
+
+    A name is a {e global} if it occurs in [main] or in any procedure's [writes]
+    clause; every other name in a procedure is that procedure's {e local}. This
+    split matters because a procedure only sees the globals it declares in
+    [writes]. A name used as an array (indexed, [len]-ed, created, or
+    element-assigned) is given a [map int int] symbol plus a companion length
+    variable (see {!Vars.len_key}); all other names are scalar integers. *)

--- a/src/ast/vars.mli
+++ b/src/ast/vars.mli
@@ -1,3 +1,8 @@
+(** The variable environment: a map from source names to the Why3 [vsymbol]s
+    that stand for them in translated terms. {!Var_collection} builds these (one
+    per procedure, one for [main]'s globals); {!Logic} and [Hoare] look names up
+    in them. *)
+
 module T = Why3.Term
 
 (* module M : sig
@@ -7,11 +12,20 @@ module T = Why3.Term
    type t = T.vsymbol M.t *)
 
 type t
+(** A name-to-[vsymbol] environment. *)
 
 val empty : t
+
 val find : string -> t -> T.vsymbol
+(** Look a name up in the environment. Raises the internal [Var_not_found] if it
+    is unbound; use {!find_opt} to handle absence. *)
+
 val find_opt : string -> t -> T.vsymbol option
+
 val find_fallback : string -> t -> t -> T.vsymbol
+(** [find_fallback s a b] looks [s] up in [a], falling back to [b]. Used to
+    resolve a name against procedure-locals first, then globals. *)
+
 val add : string -> T.vsymbol -> t -> t
 val bindings : t -> (string * T.vsymbol) list
 
@@ -20,7 +34,10 @@ val union : t -> t -> t
     from [a] *)
 
 val fold : (string -> T.vsymbol -> 'a -> 'a) -> t -> 'a -> 'a
+
 val create_fresh : string -> Why3.Term.vsymbol
+(** A fresh integer-valued ([int]) [vsymbol] with a unique name derived from the
+    argument. *)
 
 val create_fresh_array : string -> Why3.Term.vsymbol
 (** A fresh array-valued ([map int int]) variable. *)

--- a/src/compile.mli
+++ b/src/compile.mli
@@ -1,0 +1,33 @@
+(** Ahead-of-time backend: transpile the typed AST to OCaml source and build it
+    into a native executable. Behind [cav compile], driven by {!Main.compile}.
+
+    Cavalry integers are Why3's {e unbounded} mathematical integers -- the model
+    {!Hoare.verify} proves against -- so {!emit} defaults to arbitrary-precision
+    Zarith arithmetic, keeping the compiled program's integer model identical to
+    the verified one. [native_int] instead emits OCaml's 63-bit [int], which
+    wraps; it is sound only when paired with the machine-integer verification
+    gate that proves overflow cannot happen (see {!Main.compile}). *)
+
+open Ast
+
+exception Unsupported of string
+(** Raised for a Cavalry feature the backend cannot yet compile. Kept distinct
+    from {!Toolchain_error} so the CLI can phrase each differently. *)
+
+exception Toolchain_error of string
+(** Raised when the external OCaml toolchain is missing or rejects the emitted
+    source -- e.g. [ocamlfind]/[ocamlopt] not found, or a non-zero exit. *)
+
+val emit : ?native_int:bool -> (Triple.t * Vars.t) list -> string
+(** Transpile a verified program -- procedures followed by [main] -- to OCaml
+    source. With [native_int] the emitted code computes in native [int];
+    otherwise (default) in Zarith. This choice must match the one {!to_native}
+    is given, so the source and the link line agree. *)
+
+val to_native : ?native_int:bool -> output:string -> string -> unit
+(** [to_native ~output source] builds the OCaml [source] into a native
+    executable at [output] by shelling out to [ocamlfind ocamlopt], linking
+    Zarith unless [native_int]. The source and ocamlopt's intermediate artifacts
+    go in a temp file that is removed afterwards; only [output] survives.
+
+    @raise Toolchain_error if the toolchain is absent or compilation fails. *)

--- a/src/dune
+++ b/src/dune
@@ -1,5 +1,6 @@
 (library
  (name cavalry)
+ (public_name cavalry)
  (libraries core why3 ast smt parse)
  (preprocess
   (pps ppx_jane)))

--- a/src/hoare.mli
+++ b/src/hoare.mli
@@ -1,6 +1,16 @@
+(** The verifier: the weakest-liberal-precondition calculus that turns each
+    Hoare triple [{p} c {q}] into a Why3 goal [p -> wlp(c, q)] and discharges it
+    through {!Smt.Prover}.
+
+    Procedures are verified bottom-up (a callee before any caller) and calls are
+    handled by substitution and havoc rather than inlining, so a procedure's
+    body is proven once against its own contract. *)
+
 module T = Why3.Term
 open Ast
 
+(** Procedures in scope during WLP, keyed by name, so a call site can look up
+    its callee's contract. *)
 module Proc_map : sig
   type 'a t
 end

--- a/src/main.mli
+++ b/src/main.mli
@@ -1,7 +1,13 @@
+(** The library entry point wiring the pipeline together: parse a source file,
+    then either verify it, run it, or compile it. The [cav] CLI in [bin/main.ml]
+    is a thin cmdliner shell over these. *)
+
 module Ast = Ast
 open Ast
 
 val get_ast : string -> (Triple.t * Vars.t) list
+(** Parse the source file at the given path and run variable collection,
+    producing the annotated triples that {!verify} and {!Hoare} consume. *)
 
 val verify :
   ?debug:bool ->
@@ -9,8 +15,12 @@ val verify :
   ?machine_int:bool ->
   (Triple.t * Vars.t) list ->
   Smt.Prover.result
+(** Verify a parsed program. See {!Hoare.verify} for [machine_int] and the other
+    parameters. *)
 
 val exec : string -> int
+(** Parse and interpret the source file at the given path, returning [main]'s
+    result. Backs [cav run]. *)
 
 exception Verification_failed of string
 (** Raised by [compile] when its verification gate rejects the program. *)

--- a/src/smt/dune
+++ b/src/smt/dune
@@ -1,5 +1,6 @@
 (library
  (name smt)
+ (public_name cavalry.smt)
  (libraries core why3)
  (preprocess
   (pps ppx_jane ppx_deriving.ord)))

--- a/src/smt/prover.mli
+++ b/src/smt/prover.mli
@@ -1,7 +1,16 @@
+(** The SMT backend: a thin wrapper over Why3 driving Alt-Ergo. The prover
+    (pinned to 2.4.3) and its driver are loaded once at module initialisation,
+    failing fast with [exit 1] if [why3 config detect] has not found it. *)
+
 open Why3
 
 val env : Env.env
+(** The Why3 environment (theory load path), shared so callers can build tasks
+    that reference the standard library. *)
 
+(** A goal's outcome: [Valid] (proven), [Invalid] (a counter-model or [unknown]
+    -- not proven), or [Failed] (timeout, out-of-memory, or prover error),
+    carrying the raw prover output. *)
 type result = Valid | Invalid | Failed of string [@@deriving sexp_of, ord]
 
 val result_of_answer : output:string -> Call_provers.prover_answer -> result
@@ -10,3 +19,6 @@ val result_of_answer : output:string -> Call_provers.prover_answer -> result
 
 val prove :
   float option -> Task.task -> Term.vsymbol list -> Term.term -> result
+(** [prove timeout task vars goal] universally closes [goal] over [vars], adds
+    it to [task] as the goal, and runs Alt-Ergo. [timeout] is a per-goal time
+    limit in seconds ([None] for unlimited). *)


### PR DESCRIPTION
Closes #8.

Cavalry's modules were exposed through `.mli` files but many of their `val`s,
types, and exceptions were undocumented, and there was no way to render an API
site. This branch documents the interface and wires up odoc so `dune build @doc`
produces a browsable set of HTML pages.

## What changed

**Document the public interface.** Every `.mli` gains a module preamble placing
it in the parse → type → resolve → verify/run pipeline, and each previously bare
`val`, type, and exception is described. Signatures are untouched — no behaviour
change.

**Add odoc.** The four libraries (`cavalry`, `cavalry.ast`, `cavalry.smt`,
`cavalry.parse`) get public names so they belong to the package and render under
the standard `@doc` target; the test library stays private and is excluded. A
package landing page (`doc/index.mld`) introduces the pipeline and links the key
modules. odoc is a `with-doc` dependency, and CI installs it and runs
`dune build @doc`, so a broken reference or malformed comment fails the build
rather than rotting.

**Curate the `Compile` surface.** `Compile` had no interface, so its whole
implementation — the `Str_set` helper, the `ops` backend record, every `emit_*`
helper — was public. A new `src/compile.mli` restricts it to the four members
callers use (`Unsupported`, `Toolchain_error`, `emit`, `to_native`).

## Generating the docs

```
dune build @doc
# open _build/default/_doc/_html/index.html
```

## Not included

The issue also mentions *hosting* the docs. This PR generates them and gates
them in CI but does not deploy anywhere (e.g. GitHub Pages). That can be a
follow-up — happy to add a Pages workflow if wanted.