### PR TITLE
verify: actionable failure diagnostics (procedure, reason, location)

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -5,12 +5,18 @@ let exec source_file = Printf.printf "%d\n" (Main.exec source_file)
 let verify debug machine_int source_file =
   let program = Main.get_ast source_file in
   let open Smt.Prover in
-  match Main.verify ~debug ~machine_int program with
-  | Valid -> Printf.printf "verification successful\n"
-  | Invalid ->
+  match Main.verify_report ~debug ~machine_int program with
+  | { result = Valid; _ } -> Printf.printf "verification successful\n"
+  | { result = Invalid; failing_proc } ->
+      let where =
+        match failing_proc with
+        | Some p -> Printf.sprintf " in procedure '%s'" p
+        | None -> ""
+      in
       Printf.printf
-        "verification unsuccessful: precondition does not imply postcondition\n"
-  | Failed s -> Printf.printf "internal failure: %s\n" s
+        "verification unsuccessful%s: precondition does not imply postcondition\n"
+        where
+  | { result = Failed s; _ } -> Printf.printf "internal failure: %s\n" s
 
 let compile debug no_verify native_int output source_file =
   let output =

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -7,15 +7,18 @@ let verify debug machine_int source_file =
   let open Smt.Prover in
   match Main.verify_report ~debug ~machine_int program with
   | { result = Valid; _ } -> Printf.printf "verification successful\n"
-  | { result = Invalid; failing_proc } ->
+  | { result = Invalid; failing_proc; reason } ->
       let where =
         match failing_proc with
         | Some p -> Printf.sprintf " in procedure '%s'" p
         | None -> ""
       in
-      Printf.printf
-        "verification unsuccessful%s: precondition does not imply postcondition\n"
-        where
+      let what =
+        match reason with
+        | Some r -> Hoare.expl_of_reason r
+        | None -> "precondition does not imply postcondition"
+      in
+      Printf.printf "verification unsuccessful%s: %s\n" where what
   | { result = Failed s; _ } -> Printf.printf "internal failure: %s\n" s
 
 let compile debug no_verify native_int output source_file =

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -7,10 +7,15 @@ let verify debug machine_int source_file =
   let open Smt.Prover in
   match Main.verify_report ~debug ~machine_int program with
   | { result = Valid; _ } -> Printf.printf "verification successful\n"
-  | { result = Invalid; failing_proc; reason } ->
+  | { result = Invalid; failing_proc; reason; loc } ->
       let where =
         match failing_proc with
         | Some p -> Printf.sprintf " in procedure '%s'" p
+        | None -> ""
+      in
+      let at =
+        match loc with
+        | Some l -> Printf.sprintf " at %s" (Ast.Loc.to_string l)
         | None -> ""
       in
       let what =
@@ -18,7 +23,7 @@ let verify debug machine_int source_file =
         | Some r -> Hoare.expl_of_reason r
         | None -> "precondition does not imply postcondition"
       in
-      Printf.printf "verification unsuccessful%s: %s\n" where what
+      Printf.printf "verification unsuccessful%s%s: %s\n" where at what
   | { result = Failed s; _ } -> Printf.printf "internal failure: %s\n" s
 
 let compile debug no_verify native_int output source_file =

--- a/src/ast/loc.ml
+++ b/src/ast/loc.ml
@@ -1,0 +1,32 @@
+open Core
+
+(* A source location: the start position of a syntactic construct, enough to
+   print [file:line:col] and to build a Why3 [Loc.position] for the verifier to
+   carry through the WLP. Only the *start* is kept -- error messages point at
+   where a construct begins, which is what a user scans for. *)
+type t = { file : string; line : int; col : int } [@@deriving sexp_of, show]
+
+(* Build a location from a Menhir [$loc] span (a start/end [Lexing.position]
+   pair); only the start is retained. Requires the lexer to track newlines
+   ([Lexing.new_line]) for [pos_lnum]/[pos_bol] to be accurate. *)
+let of_span ((start, _) : Lexing.position * Lexing.position) : t =
+  {
+    file = start.Lexing.pos_fname;
+    line = start.Lexing.pos_lnum;
+    (* 1-based column, matching the [file:line:col] convention of gcc/rust and
+       most editors ([pos_cnum - pos_bol] is 0-based). *)
+    col = start.Lexing.pos_cnum - start.Lexing.pos_bol + 1;
+  }
+
+let to_string { file; line; col } =
+  if String.length file = 0 then Printf.sprintf "%d:%d" line col
+  else Printf.sprintf "%s:%d:%d" file line col
+
+(* The verifier tags each proof obligation's Why3 term with this position, so a
+   failing (split) subgoal can be traced back to source. Why3 wants a range; a
+   degenerate start=end range is fine for a point diagnostic. *)
+let to_why3 { file; line; col } = Why3.Loc.user_position file line col line col
+
+let of_why3 (p : Why3.Loc.position) : t =
+  let file, line, col, _, _ = Why3.Loc.get p in
+  { file; line; col }

--- a/src/ast/parse/lexer.mll
+++ b/src/ast/parse/lexer.mll
@@ -7,7 +7,9 @@ exception Error of error
 }
 
 rule main = parse
-  | [' ' '\t' '\n']
+  | '\n'
+      { Lexing.new_line lexbuf; main lexbuf }
+  | [' ' '\t']
       { main lexbuf }
   | "//"
       { comment lexbuf }
@@ -113,7 +115,7 @@ rule main = parse
 (* A [//] line comment runs to the next newline (or eof). *)
 and comment = parse
   | '\n'
-      { main lexbuf }
+      { Lexing.new_line lexbuf; main lexbuf }
   | eof
       { EOF }
   | _

--- a/src/ast/parse/program.mly
+++ b/src/ast/parse/program.mly
@@ -5,6 +5,7 @@
 %type <Ast.Logic.arith_expr option> variant_opt
 %type <string list> variable_list
 %type <Ast.Program.ut_expr> command
+%type <Ast.Program.ut_expr> command_desc
 %type <Ast.Program.ut_expr> expr
 %type <Ast.Program.ut_expr list> expression_list
 
@@ -39,6 +40,10 @@ main:
       { { Ast.Triple.p; q; variant = None; ws = []; f="main"; ps=[]; u } }
 ;
 command:
+  | c = command_desc
+      { ULoc (Ast.Loc.of_span $loc, c) }
+;
+command_desc:
   | v = VAR ASSGN ARRAY LPAREN n = expr RPAREN
       { UArrMake (v, n) }
   | a = VAR LBRACKET i = expr RBRACKET ASSGN e = expr

--- a/src/ast/program.ml
+++ b/src/ast/program.ml
@@ -36,6 +36,9 @@ type cmd =
   | Print of int expr
   | ArrMake of string * int expr (* a <- array(n) *)
   | ArrAssgn of string * int expr * int expr (* a[i] <- e *)
+  | Located of Loc.t * cmd
+    (* a command annotated with its source location, used to point error
+       messages at the construct whose obligation failed *)
 [@@deriving sexp_of]
 
 type ut_expr =
@@ -64,6 +67,7 @@ type ut_expr =
   | ULen of string
   | UArrMake of string * ut_expr
   | UArrAssgn of string * ut_expr * ut_expr
+  | ULoc of Loc.t * ut_expr (* a command tagged with its source location *)
 [@@deriving sexp_of, show]
 
 exception TypeError of string
@@ -98,6 +102,7 @@ and expr_to_cmd = function
   | e -> raise (TypeError (show_ut_expr e))
 
 and t_cmd = function
+  | ULoc (loc, e) -> Located (loc, t_cmd e)
   | USeq (c, c') -> Seq (t_cmd c, t_cmd c')
   | UAssgn (s, e) -> Assgn (s, t_int_expr e)
   | ULet (s, e) -> Let (s, t_int_expr e)

--- a/src/ast/program.mli
+++ b/src/ast/program.mli
@@ -51,6 +51,7 @@ type cmd =
   | Print of int expr
   | ArrMake of string * int expr
   | ArrAssgn of string * int expr * int expr
+  | Located of Loc.t * cmd
 [@@deriving sexp_of]
 
 (* Untyped AST to play nice with the Menhir parser generator *)
@@ -83,6 +84,7 @@ type ut_expr =
   | ULen of string
   | UArrMake of string * ut_expr
   | UArrAssgn of string * ut_expr * ut_expr
+  | ULoc of Loc.t * ut_expr
 [@@deriving sexp_of, show]
 
 exception TypeError of string

--- a/src/ast/runtime.ml
+++ b/src/ast/runtime.ml
@@ -145,6 +145,7 @@ let rec exec_expr : type a. Runtime.t -> a expr -> a =
 and exec_cmd ?(fuel = ref max_int) r c : int * Runtime.t =
   let exec_cmd r c = exec_cmd ~fuel r c in
   match c with
+  | Located (_, c) -> exec_cmd r c
   | Seq (c, c') ->
       let _, r' = exec_cmd r c in
       exec_cmd r' c'

--- a/src/ast/var_collection.ml
+++ b/src/ast/var_collection.ml
@@ -68,6 +68,7 @@ let collect_program c =
     | Len a -> Str_set.singleton a
   in
   let rec collect_cmd = function
+    | Located (_, c) -> collect_cmd c
     | IntExpr e -> collect_expr e
     | Seq (c, c') -> Str_set.union (collect_cmd c) (collect_cmd c')
     | Assgn (x, e) | Let (x, e) ->
@@ -139,6 +140,7 @@ let arrays_program c =
         Str_set.union (expr a) (expr b)
   in
   let rec cmd = function
+    | Located (_, c) -> cmd c
     | IntExpr e | Print e | Assgn (_, e) | Let (_, e) -> expr e
     | Seq (a, b) -> Str_set.union (cmd a) (cmd b)
     | If (b, c, c') -> Str_set.union (expr b) (Str_set.union (cmd c) (cmd c'))

--- a/src/compile.ml
+++ b/src/compile.ml
@@ -115,6 +115,7 @@ let native =
    separately (see [arrays]) since they compile to an [array ref], not an
    [int ref]. *)
 let rec assigned = function
+  | Located (_, c) -> assigned c
   | Seq (c, c') -> Str_set.union (assigned c) (assigned c')
   | Assgn (x, _) -> Str_set.singleton x
   | If (_, c, c') -> Str_set.union (assigned c) (assigned c')
@@ -142,6 +143,7 @@ let rec arrays_expr : type a. a expr -> Str_set.t = function
       Str_set.union (arrays_expr a) (arrays_expr b)
 
 let rec arrays = function
+  | Located (_, c) -> arrays c
   | Seq (c, c') -> Str_set.union (arrays c) (arrays c')
   | If (_, c, c') -> Str_set.union (arrays c) (arrays c')
   | While (_, _, _, c) -> arrays c
@@ -197,7 +199,10 @@ let emit_bool ~ops ~locals (e : bool expr) : string =
 
 (* Flatten the (possibly unbalanced) [Seq] tree into left-to-right statement
    order, so a [Let] can scope over everything sequenced after it. *)
-let rec flatten = function Seq (c, c') -> flatten c @ flatten c' | c -> [ c ]
+let rec flatten = function
+  | Seq (c, c') -> flatten c @ flatten c'
+  | Located (_, c) -> flatten c
+  | c -> [ c ]
 
 (* Each command compiles to an OCaml expression of the backend int type whose
    evaluation performs its effects and yields its *value* -- the int the
@@ -207,6 +212,7 @@ let rec flatten = function Seq (c, c') -> flatten c @ flatten c' | c -> [ c ]
    [Seq] -> its last. *)
 let rec emit_cmd ~ops ~locals c : string =
   match c with
+  | Located (_, c) -> emit_cmd ~ops ~locals c
   | Seq _ -> emit_block ~ops ~locals (flatten c)
   | Assgn (x, e) ->
       Printf.sprintf "(%s := %s; %s)" (gref x) (emit_int ~ops ~locals e)

--- a/src/hoare.ml
+++ b/src/hoare.ml
@@ -3,6 +3,66 @@ open Ast.Program
 module T = Why3.Term
 module Ty = Why3.Ty
 
+(* Why a verification obligation can fail. Each proof obligation the WLP emits
+   is tagged (via [tag]) with one of these; when Alt-Ergo rejects a split
+   subgoal, its tag is recovered to classify the failure for the user. *)
+type reason =
+  | Postcondition
+  | Loop_invariant_init
+  | Loop_invariant_preserved
+  | Loop_variant
+  | Recursive_variant
+  | Call_precondition
+  | Array_bounds
+  | Array_length_nonneg
+  | Nonzero_divisor
+  | No_overflow
+  | Undeclared_write
+[@@deriving sexp_of, compare]
+
+(* The human-readable explanation carried in the Why3 [expl:] attribute. This is
+   both what the splitter propagates onto each subgoal and what the CLI prints,
+   so it must round-trip through [reason_of_expl]. *)
+let expl_of_reason = function
+  | Postcondition -> "postcondition may not hold"
+  | Loop_invariant_init -> "loop invariant may not hold on entry"
+  | Loop_invariant_preserved -> "loop invariant may not be preserved"
+  | Loop_variant -> "loop variant may not decrease"
+  | Recursive_variant -> "recursive call's variant may not decrease"
+  | Call_precondition -> "callee precondition may not hold"
+  | Array_bounds -> "array index may be out of bounds"
+  | Array_length_nonneg -> "array length may be negative"
+  | Nonzero_divisor -> "divisor may be zero"
+  | No_overflow -> "arithmetic may overflow"
+  | Undeclared_write -> "assigns a global absent from its writes clause"
+
+let all_reasons =
+  [
+    Postcondition;
+    Loop_invariant_init;
+    Loop_invariant_preserved;
+    Loop_variant;
+    Recursive_variant;
+    Call_precondition;
+    Array_bounds;
+    Array_length_nonneg;
+    Nonzero_divisor;
+    No_overflow;
+    Undeclared_write;
+  ]
+
+let reason_of_expl s =
+  List.find_opt (fun r -> String.equal (expl_of_reason r) s) all_reasons
+
+(* Tag every node of [t] with [reason]'s [expl:] attribute. Tagging only the
+   root is not enough: [split_goal_right] breaks a conjunctive obligation into
+   one subgoal per conjunct, and an attribute on the conjunction node is lost --
+   so the reason must be present on every atom the split can isolate. *)
+let tag reason t =
+  let attr = Why3.Ident.create_attribute ("expl:" ^ expl_of_reason reason) in
+  let rec go t = T.t_attr_add attr (T.t_map go t) in
+  go t
+
 (* Split a list [l @ \[m\]] into the tuple [(l, m)] *)
 let split_last l =
   let rec aux acc = function
@@ -71,7 +131,8 @@ let rec expr_to_term : type a.
    shared by array reads (in [defined]) and element writes (in [Wlp.cmd]). *)
 let index_in_bounds ~g_vars ?l_vars a i_term =
   let len = expr_to_term ~g_vars ?l_vars (Len a) in
-  T.t_and (Arith.leq (T.t_nat_const 0) i_term) (Arith.lt i_term len)
+  tag Array_bounds
+    (T.t_and (Arith.leq (T.t_nat_const 0) i_term) (Arith.lt i_term len))
 
 (* Overflow-freedom obligation for an expression: the conjunction of
    [Arith.in_bounds] over every arithmetic *result* it computes (each
@@ -93,7 +154,9 @@ let rec safe : type a. g_vars:Vars.t -> ?l_vars:Vars.t -> a expr -> T.term =
          Well-definedness (a non-zero divisor) is a separate, always-on
          obligation -- see [defined]. *)
       let operands = T.t_and_simp (self a) (self b) in
-      let result = Arith.in_bounds (expr_to_term ~g_vars ?l_vars e) in
+      let result =
+        tag No_overflow (Arith.in_bounds (expr_to_term ~g_vars ?l_vars e))
+      in
       T.t_and_simp operands result
   | Mod (a, b) ->
       (* [a mod b] is bounded in magnitude by [b], so if the operands are in
@@ -124,7 +187,8 @@ let rec defined : type a. g_vars:Vars.t -> ?l_vars:Vars.t -> a expr -> T.term =
   | Plus (a, b) | Sub (a, b) | Mul (a, b) -> T.t_and_simp (self a) (self b)
   | Div (a, b) | Mod (a, b) ->
       let nonzero =
-        Arith.neq (expr_to_term ~g_vars ?l_vars b) (T.t_nat_const 0)
+        tag Nonzero_divisor
+          (Arith.neq (expr_to_term ~g_vars ?l_vars b) (T.t_nat_const 0))
       in
       T.t_and_simp (T.t_and_simp (self a) (self b)) nonzero
   | Get (a, i) ->
@@ -203,8 +267,8 @@ module Wlp = struct
     in
     (* q_f[x_i <- e_i] *)
     let post = sub_params q_f in
-    (* p_f[x_i <- e_i] *)
-    let pre = sub_params p_f in
+    (* p_f[x_i <- e_i] -- the callee precondition the caller must establish *)
+    let pre = tag Call_precondition (sub_params p_f) in
     let sub_written_vars p =
       (* Writing an array havocs both its element map and its length (a callee
          may re-create it with [array(n)]); a scalar havocs just itself. *)
@@ -271,7 +335,9 @@ module Wlp = struct
         let q_sub =
           T.t_subst (T.Mvs.of_list [ (a_v, Arith.azero); (len_v, n_t) ]) q
         in
-        let nonneg = Arith.leq (T.t_nat_const 0) n_t in
+        let nonneg =
+          tag Array_length_nonneg (Arith.leq (T.t_nat_const 0) n_t)
+        in
         T.t_and_simp (safe_e n) (T.t_and_simp nonneg q_sub)
     | ArrAssgn (a, i, e) ->
         (* a[i] <- e: safe(i) /\ safe(e) /\ 0 <= i < len(a)
@@ -313,9 +379,10 @@ module Wlp = struct
                   triple.Triple.ps ps
               in
               let v_actuals = T.t_subst (T.Mvs.of_list sub) v_formals in
-              T.t_and
-                (Arith.leq (T.t_nat_const 0) v_actuals)
-                (Arith.lt v_actuals v_formals)
+              tag Recursive_variant
+                (T.t_and
+                   (Arith.leq (T.t_nat_const 0) v_actuals)
+                   (Arith.lt v_actuals v_formals))
           | _ -> T.t_true
         in
         T.t_and_simp decrease
@@ -351,15 +418,22 @@ module Wlp = struct
            post-body measure -- so the obligation is post-V < pre-V. *)
         let guard = expr_to_term ~g_vars ~l_vars b in
         let inv_t = Logic.translate_term ~g_vars ~l_vars inv in
+        (* The invariant plays three roles below: proven to hold on entry
+           ([Loop_invariant_init]), proven re-established by the body (as the
+           WLP target, [Loop_invariant_preserved]), and assumed as a hypothesis
+           (left untagged). *)
+        let inv_pres = tag Loop_invariant_preserved inv_t in
         let s =
           match variant with
-          | None -> cmd c inv_t
+          | None -> cmd c inv_pres
           | Some measure ->
               let m = Logic.translate_arith_term ~g_vars ~l_vars measure in
               let w = Vars.create_fresh "variant" in
               let w_t = T.t_var w in
-              let decreases = cmd c (T.t_and inv_t (Arith.lt m w_t)) in
-              let bounded = Arith.leq (T.t_nat_const 0) m in
+              let decreases =
+                cmd c (T.t_and inv_pres (tag Loop_variant (Arith.lt m w_t)))
+              in
+              let bounded = tag Loop_variant (Arith.leq (T.t_nat_const 0) m) in
               T.t_forall_close [ w ] []
                 (T.t_implies (T.t_equ w_t m) (T.t_and bounded decreases))
         in
@@ -376,7 +450,9 @@ module Wlp = struct
           T.t_forall_close ys []
             (havoc_in_bounds ~machine_int ys (T.t_subst (T.Mvs.of_list map) p))
         in
-        T.t_and inv_t (havoc T.(t_and iterate (t_and_simp postcond guard_safe)))
+        T.t_and
+          (tag Loop_invariant_init inv_t)
+          (havoc T.(t_and iterate (t_and_simp postcond guard_safe)))
 end
 
 let merge_in vm x =
@@ -393,6 +469,12 @@ let verify_procedure ?timeout ~machine_int ~is_main g_vars procs
       ( Logic.translate_term ~g_vars ~l_vars t.p,
         Logic.translate_term ~g_vars ~l_vars t.q )
   in
+  (* The procedure's postcondition is the default obligation: everything the WLP
+     ultimately establishes is [q], so tag it now and let the tag ride down
+     through the calculus. More specific obligations ([safe], bounds, variants,
+     ...) are tagged at their own construction sites and, being separate split
+     subgoals, are classified on their own. *)
+  let q = tag Postcondition q in
   let p_gen =
     Wlp.(
       sub_old_vars ~g_vars ~l_vars t.ws
@@ -425,10 +507,26 @@ let verify_procedure ?timeout ~machine_int ~is_main g_vars procs
     Arith.uses_map goal
     || List.exists (fun v -> Ty.ty_equal v.T.vs_ty Arith.ty_int_map) merged_vars
   in
-  let task = Arith.task ~div:(Arith.uses_div goal) ~map:uses_map in
-  Smt.Prover.prove timeout task merged_vars goal
+  let split_task = Arith.task ~div:(Arith.uses_div goal) ~map:uses_map in
+  let obligations = Smt.Prover.split_obligations split_task merged_vars goal in
+  (* Discharge each obligation on its own task, detecting division per subgoal:
+     a subgoal that does not mention [div]/[mod] must not carry the
+     ComputerDivision axioms, on which Alt-Ergo's matching loop can diverge even
+     while ignoring the time limit (see [Arith]). Map inclusion is harmless, so
+     the whole-goal [uses_map] is reused. The first failing obligation
+     determines the reported reason. *)
+  let rec check = function
+    | [] -> (Smt.Prover.Valid, None)
+    | (f, expl) :: rest -> (
+        let task = Arith.task ~div:(Arith.uses_div f) ~map:uses_map in
+        match Smt.Prover.prove_term timeout task f with
+        | Smt.Prover.Valid -> check rest
+        | Smt.Prover.Invalid -> (Smt.Prover.Invalid, reason_of_expl expl)
+        | Smt.Prover.Failed s -> (Smt.Prover.Failed s, None))
+  in
+  check obligations
 
-exception Proc_invalid of string
+exception Proc_invalid of string * Smt.Prover.result * reason option
 
 (* A procedure's [writes] clause must name every global it actually assigns;
    otherwise a caller's WLP would never havoc that global and could "prove"
@@ -443,9 +541,14 @@ let writes_are_declared globals procs (t : Triple.t) =
 
 (* The outcome of verifying a whole program: the prover verdict, plus -- when
    the program is rejected -- the name of the first procedure ([main] included)
-   whose body failed to verify. [failing_proc] is [None] iff [result] is [Valid].
-   Later milestones enrich this with the failure's reason and source location. *)
-type report = { result : Smt.Prover.result; failing_proc : string option }
+   whose body failed to verify and, when the prover pinned it down, the reason.
+   [failing_proc] is [None] iff [result] is [Valid]. A later milestone adds the
+   failure's source location. *)
+type report = {
+  result : Smt.Prover.result;
+  failing_proc : string option;
+  reason : reason option;
+}
 
 let verify_report ?debug:d ?timeout ?(machine_int = false) program =
   debug := Option.value ~default:false d;
@@ -457,23 +560,23 @@ let verify_report ?debug:d ?timeout ?(machine_int = false) program =
        hypothesis). This lifts the earlier bottom-up ordering restriction. main
        is never a callee, so it is not registered. *)
     let procs = if is_main then procs else Proc_map.add t.f proc procs in
-    let result =
+    let result, reason =
       if (not is_main) && not (writes_are_declared globals procs t) then
-        Smt.Prover.Invalid
+        (Smt.Prover.Invalid, Some Undeclared_write)
       else verify_procedure ?timeout ~machine_int ~is_main globals procs proc
     in
     match result with
     | Valid -> procs
-    | Invalid | Failed _ -> raise (Proc_invalid t.f)
+    | Invalid | Failed _ -> raise (Proc_invalid (t.f, result, reason))
   in
   try
     let proc_map = List.fold_left (f ~is_main:false) Proc_map.empty procs in
     let (_ : (Triple.t * Vars.t) Proc_map.t) =
       f ~is_main:true proc_map (main, globals)
     in
-    { result = Smt.Prover.Valid; failing_proc = None }
-  with Proc_invalid s ->
-    { result = Smt.Prover.Invalid; failing_proc = Some s }
+    { result = Smt.Prover.Valid; failing_proc = None; reason = None }
+  with Proc_invalid (s, result, reason) ->
+    { result; failing_proc = Some s; reason }
 
 let verify ?debug ?timeout ?machine_int program =
   (verify_report ?debug ?timeout ?machine_int program).result

--- a/src/hoare.ml
+++ b/src/hoare.ml
@@ -441,7 +441,13 @@ let writes_are_declared globals procs (t : Triple.t) =
       | None -> true
       | Some _ -> List.mem x t.ws)
 
-let verify ?debug:d ?timeout ?(machine_int = false) program =
+(* The outcome of verifying a whole program: the prover verdict, plus -- when
+   the program is rejected -- the name of the first procedure ([main] included)
+   whose body failed to verify. [failing_proc] is [None] iff [result] is [Valid].
+   Later milestones enrich this with the failure's reason and source location. *)
+type report = { result : Smt.Prover.result; failing_proc : string option }
+
+let verify_report ?debug:d ?timeout ?(machine_int = false) program =
   debug := Option.value ~default:false d;
   let procs, (main, globals) = split_last program in
   let f ~is_main procs proc =
@@ -465,7 +471,9 @@ let verify ?debug:d ?timeout ?(machine_int = false) program =
     let (_ : (Triple.t * Vars.t) Proc_map.t) =
       f ~is_main:true proc_map (main, globals)
     in
-    Smt.Prover.Valid
+    { result = Smt.Prover.Valid; failing_proc = None }
   with Proc_invalid s ->
-    if !debug then Printf.printf "Procedure '%s' cannot be verified\n" s;
-    Smt.Prover.Invalid
+    { result = Smt.Prover.Invalid; failing_proc = Some s }
+
+let verify ?debug ?timeout ?machine_int program =
+  (verify_report ?debug ?timeout ?machine_int program).result

--- a/src/hoare.ml
+++ b/src/hoare.ml
@@ -54,13 +54,17 @@ let all_reasons =
 let reason_of_expl s =
   List.find_opt (fun r -> String.equal (expl_of_reason r) s) all_reasons
 
-(* Tag every node of [t] with [reason]'s [expl:] attribute. Tagging only the
-   root is not enough: [split_goal_right] breaks a conjunctive obligation into
-   one subgoal per conjunct, and an attribute on the conjunction node is lost --
-   so the reason must be present on every atom the split can isolate. *)
-let tag reason t =
+(* Tag every node of [t] with [reason]'s [expl:] attribute and, when given, its
+   source location. Tagging only the root is not enough: [split_goal_right]
+   breaks a conjunctive obligation into one subgoal per conjunct, and an
+   attribute (or location) on the conjunction node is lost -- so both must be
+   present on every atom the split can isolate. *)
+let tag ?loc reason t =
   let attr = Why3.Ident.create_attribute ("expl:" ^ expl_of_reason reason) in
-  let rec go t = T.t_attr_add attr (T.t_map go t) in
+  let rec go t =
+    let t = T.t_map go t in
+    T.t_attr_set ?loc (Why3.Ident.Sattr.add attr t.T.t_attrs) t
+  in
   go t
 
 (* Split a list [l @ \[m\]] into the tuple [(l, m)] *)
@@ -129,9 +133,9 @@ let rec expr_to_term : type a.
 
 (* [0 <= i < len(a)]: the well-definedness obligation for accessing [a\[i\]],
    shared by array reads (in [defined]) and element writes (in [Wlp.cmd]). *)
-let index_in_bounds ~g_vars ?l_vars a i_term =
+let index_in_bounds ~g_vars ?l_vars ?loc a i_term =
   let len = expr_to_term ~g_vars ?l_vars (Len a) in
-  tag Array_bounds
+  tag ?loc Array_bounds
     (T.t_and (Arith.leq (T.t_nat_const 0) i_term) (Arith.lt i_term len))
 
 (* Overflow-freedom obligation for an expression: the conjunction of
@@ -143,9 +147,14 @@ let index_in_bounds ~g_vars ?l_vars a i_term =
    yield a boolean, not a machine integer, so they add no bound of their own but
    still require their integer operands to be safe. [t_and_simp] keeps fully-safe
    expressions as [true] rather than a pile of [true /\ ...]. *)
-let rec safe : type a. g_vars:Vars.t -> ?l_vars:Vars.t -> a expr -> T.term =
- fun ~g_vars ?l_vars e ->
-  let self = safe ~g_vars ?l_vars in
+let rec safe : type a.
+    g_vars:Vars.t ->
+    ?l_vars:Vars.t ->
+    ?loc:Why3.Loc.position ->
+    a expr ->
+    T.term =
+ fun ~g_vars ?l_vars ?loc e ->
+  let self = safe ~g_vars ?l_vars ?loc in
   match e with
   | Value _ -> T.t_true
   | Plus (a, b) | Sub (a, b) | Mul (a, b) | Div (a, b) ->
@@ -155,7 +164,7 @@ let rec safe : type a. g_vars:Vars.t -> ?l_vars:Vars.t -> a expr -> T.term =
          obligation -- see [defined]. *)
       let operands = T.t_and_simp (self a) (self b) in
       let result =
-        tag No_overflow (Arith.in_bounds (expr_to_term ~g_vars ?l_vars e))
+        tag ?loc No_overflow (Arith.in_bounds (expr_to_term ~g_vars ?l_vars e))
       in
       T.t_and_simp operands result
   | Mod (a, b) ->
@@ -179,21 +188,26 @@ let rec safe : type a. g_vars:Vars.t -> ?l_vars:Vars.t -> a expr -> T.term =
    divisor and the interpreter/compiled binary would raise [Division_by_zero],
    so a verified program must prove it never divides by zero. [t_and_simp]
    collapses division-free expressions back to [true]. *)
-let rec defined : type a. g_vars:Vars.t -> ?l_vars:Vars.t -> a expr -> T.term =
- fun ~g_vars ?l_vars e ->
-  let self = defined ~g_vars ?l_vars in
+let rec defined : type a.
+    g_vars:Vars.t ->
+    ?l_vars:Vars.t ->
+    ?loc:Why3.Loc.position ->
+    a expr ->
+    T.term =
+ fun ~g_vars ?l_vars ?loc e ->
+  let self = defined ~g_vars ?l_vars ?loc in
   match e with
   | Value _ -> T.t_true
   | Plus (a, b) | Sub (a, b) | Mul (a, b) -> T.t_and_simp (self a) (self b)
   | Div (a, b) | Mod (a, b) ->
       let nonzero =
-        tag Nonzero_divisor
+        tag ?loc Nonzero_divisor
           (Arith.neq (expr_to_term ~g_vars ?l_vars b) (T.t_nat_const 0))
       in
       T.t_and_simp (T.t_and_simp (self a) (self b)) nonzero
   | Get (a, i) ->
       let bounds =
-        index_in_bounds ~g_vars ?l_vars a (expr_to_term ~g_vars ?l_vars i)
+        index_in_bounds ~g_vars ?l_vars ?loc a (expr_to_term ~g_vars ?l_vars i)
       in
       T.t_and_simp (self i) bounds
   | Len _ -> T.t_true
@@ -207,6 +221,7 @@ module Proc_map = Map.Make (String)
    check that a procedure's declared [writes] covers what it actually mutates. *)
 let rec assigned_vars procs c =
   match c with
+  | Located (_, c) -> assigned_vars procs c
   | Assgn (x, _) | Let (x, _) -> [ x ]
   | Seq (a, b) | If (_, a, b) -> assigned_vars procs a @ assigned_vars procs b
   | While (_, _, _, body) -> assigned_vars procs body
@@ -254,7 +269,7 @@ module Wlp = struct
       in
       T.t_implies_simp premise body
 
-  let proc ~machine_int g_vars q l_vars ps (t : Triple.t) =
+  let proc ~machine_int ?loc g_vars q l_vars ps (t : Triple.t) =
     let p_f = Logic.translate_term ~g_vars ~l_vars t.p in
     let q_f = Logic.translate_term ~g_vars ~l_vars t.q in
     let sub_params p =
@@ -268,7 +283,7 @@ module Wlp = struct
     (* q_f[x_i <- e_i] *)
     let post = sub_params q_f in
     (* p_f[x_i <- e_i] -- the callee precondition the caller must establish *)
-    let pre = tag Call_precondition (sub_params p_f) in
+    let pre = tag ?loc Call_precondition (sub_params p_f) in
     let sub_written_vars p =
       (* Writing an array havocs both its element map and its length (a callee
          may re-create it with [array(n)]); a scalar havocs just itself. *)
@@ -300,16 +315,26 @@ module Wlp = struct
      case). *)
   let rec cmd procs ~machine_int ~self ~g_vars ~l_vars c q =
     let cmd = cmd procs ~machine_int ~self ~g_vars ~l_vars in
+    (* Peel the source location off the command; its obligations are tagged with
+       it so a failing subgoal can be traced back to this construct. *)
+    let loc, c =
+      match c with Located (l, c) -> (Some (Loc.to_why3 l), c) | c -> (None, c)
+    in
     (* Well-definedness obligations for an expression evaluated by [c]. The
        divisor-non-zero part ([defined]) is always imposed; the overflow-freedom
        part ([safe]) only in machine-integer mode. In the default (unbounded,
        division-free) case both collapse to [true] and the WLP is unchanged. *)
     let safe_e : type a. a expr -> T.term =
      fun e ->
-      let overflow = if machine_int then safe ~g_vars ~l_vars e else T.t_true in
-      T.t_and_simp (defined ~g_vars ~l_vars e) overflow
+      let overflow =
+        if machine_int then safe ~g_vars ~l_vars ?loc e else T.t_true
+      in
+      T.t_and_simp (defined ~g_vars ~l_vars ?loc e) overflow
     in
     match c with
+    (* [Located] is peeled above; this arm is unreachable but keeps the match
+       total (a nested wrapper would simply recurse). *)
+    | Located (_, c) -> cmd c q
     (* [IntExpr]/[Print] do not change the state but do evaluate their argument,
        so its arithmetic must not overflow. *)
     | IntExpr e -> T.t_and_simp (safe_e e) q
@@ -336,7 +361,7 @@ module Wlp = struct
           T.t_subst (T.Mvs.of_list [ (a_v, Arith.azero); (len_v, n_t) ]) q
         in
         let nonneg =
-          tag Array_length_nonneg (Arith.leq (T.t_nat_const 0) n_t)
+          tag ?loc Array_length_nonneg (Arith.leq (T.t_nat_const 0) n_t)
         in
         T.t_and_simp (safe_e n) (T.t_and_simp nonneg q_sub)
     | ArrAssgn (a, i, e) ->
@@ -346,7 +371,7 @@ module Wlp = struct
         let e_t = expr_to_term ~g_vars ~l_vars e in
         let a_v = Vars.find_fallback a l_vars g_vars in
         let q_sub = T.t_subst_single a_v (Arith.aset (T.t_var a_v) i_t e_t) q in
-        let bounds = index_in_bounds ~g_vars ~l_vars a i_t in
+        let bounds = index_in_bounds ~g_vars ~l_vars ?loc a i_t in
         T.t_and_simp
           (T.t_and_simp (safe_e i) (safe_e e))
           (T.t_and_simp bounds q_sub)
@@ -379,7 +404,7 @@ module Wlp = struct
                   triple.Triple.ps ps
               in
               let v_actuals = T.t_subst (T.Mvs.of_list sub) v_formals in
-              tag Recursive_variant
+              tag ?loc Recursive_variant
                 (T.t_and
                    (Arith.leq (T.t_nat_const 0) v_actuals)
                    (Arith.lt v_actuals v_formals))
@@ -387,7 +412,7 @@ module Wlp = struct
         in
         T.t_and_simp decrease
           (T.t_and_simp args_safe
-             (proc ~machine_int g_vars q callee_l_vars ps triple))
+             (proc ~machine_int ?loc g_vars q callee_l_vars ps triple))
     | If (b, c, c') ->
         (* safe(b) /\ ( b -> wlp(c, q) ) /\ ( ~b -> wlp(c', q) ) *)
         let t = expr_to_term ~g_vars ~l_vars b in
@@ -422,7 +447,7 @@ module Wlp = struct
            ([Loop_invariant_init]), proven re-established by the body (as the
            WLP target, [Loop_invariant_preserved]), and assumed as a hypothesis
            (left untagged). *)
-        let inv_pres = tag Loop_invariant_preserved inv_t in
+        let inv_pres = tag ?loc Loop_invariant_preserved inv_t in
         let s =
           match variant with
           | None -> cmd c inv_pres
@@ -431,9 +456,12 @@ module Wlp = struct
               let w = Vars.create_fresh "variant" in
               let w_t = T.t_var w in
               let decreases =
-                cmd c (T.t_and inv_pres (tag Loop_variant (Arith.lt m w_t)))
+                cmd c
+                  (T.t_and inv_pres (tag ?loc Loop_variant (Arith.lt m w_t)))
               in
-              let bounded = tag Loop_variant (Arith.leq (T.t_nat_const 0) m) in
+              let bounded =
+                tag ?loc Loop_variant (Arith.leq (T.t_nat_const 0) m)
+              in
               T.t_forall_close [ w ] []
                 (T.t_implies (T.t_equ w_t m) (T.t_and bounded decreases))
         in
@@ -451,7 +479,7 @@ module Wlp = struct
             (havoc_in_bounds ~machine_int ys (T.t_subst (T.Mvs.of_list map) p))
         in
         T.t_and
-          (tag Loop_invariant_init inv_t)
+          (tag ?loc Loop_invariant_init inv_t)
           (havoc T.(t_and iterate (t_and_simp postcond guard_safe)))
 end
 
@@ -514,19 +542,21 @@ let verify_procedure ?timeout ~machine_int ~is_main g_vars procs
      ComputerDivision axioms, on which Alt-Ergo's matching loop can diverge even
      while ignoring the time limit (see [Arith]). Map inclusion is harmless, so
      the whole-goal [uses_map] is reused. The first failing obligation
-     determines the reported reason. *)
+     determines the reported reason and location. *)
   let rec check = function
-    | [] -> (Smt.Prover.Valid, None)
-    | (f, expl) :: rest -> (
+    | [] -> (Smt.Prover.Valid, None, None)
+    | (f, expl, loc) :: rest -> (
         let task = Arith.task ~div:(Arith.uses_div f) ~map:uses_map in
         match Smt.Prover.prove_term timeout task f with
         | Smt.Prover.Valid -> check rest
-        | Smt.Prover.Invalid -> (Smt.Prover.Invalid, reason_of_expl expl)
-        | Smt.Prover.Failed s -> (Smt.Prover.Failed s, None))
+        | Smt.Prover.Invalid ->
+            (Smt.Prover.Invalid, reason_of_expl expl, Option.map Loc.of_why3 loc)
+        | Smt.Prover.Failed s -> (Smt.Prover.Failed s, None, None))
   in
   check obligations
 
-exception Proc_invalid of string * Smt.Prover.result * reason option
+exception
+  Proc_invalid of string * Smt.Prover.result * reason option * Loc.t option
 
 (* A procedure's [writes] clause must name every global it actually assigns;
    otherwise a caller's WLP would never havoc that global and could "prove"
@@ -541,13 +571,15 @@ let writes_are_declared globals procs (t : Triple.t) =
 
 (* The outcome of verifying a whole program: the prover verdict, plus -- when
    the program is rejected -- the name of the first procedure ([main] included)
-   whose body failed to verify and, when the prover pinned it down, the reason.
-   [failing_proc] is [None] iff [result] is [Valid]. A later milestone adds the
-   failure's source location. *)
+   whose body failed to verify, the reason, and the source location of the
+   offending construct. [failing_proc] is [None] iff [result] is [Valid]. [loc]
+   is [None] for whole-procedure obligations (e.g. a plain postcondition, which
+   is not tied to one construct) and for static rejections. *)
 type report = {
   result : Smt.Prover.result;
   failing_proc : string option;
   reason : reason option;
+  loc : Loc.t option;
 }
 
 let verify_report ?debug:d ?timeout ?(machine_int = false) program =
@@ -560,23 +592,28 @@ let verify_report ?debug:d ?timeout ?(machine_int = false) program =
        hypothesis). This lifts the earlier bottom-up ordering restriction. main
        is never a callee, so it is not registered. *)
     let procs = if is_main then procs else Proc_map.add t.f proc procs in
-    let result, reason =
+    let result, reason, loc =
       if (not is_main) && not (writes_are_declared globals procs t) then
-        (Smt.Prover.Invalid, Some Undeclared_write)
+        (Smt.Prover.Invalid, Some Undeclared_write, None)
       else verify_procedure ?timeout ~machine_int ~is_main globals procs proc
     in
     match result with
     | Valid -> procs
-    | Invalid | Failed _ -> raise (Proc_invalid (t.f, result, reason))
+    | Invalid | Failed _ -> raise (Proc_invalid (t.f, result, reason, loc))
   in
   try
     let proc_map = List.fold_left (f ~is_main:false) Proc_map.empty procs in
     let (_ : (Triple.t * Vars.t) Proc_map.t) =
       f ~is_main:true proc_map (main, globals)
     in
-    { result = Smt.Prover.Valid; failing_proc = None; reason = None }
-  with Proc_invalid (s, result, reason) ->
-    { result; failing_proc = Some s; reason }
+    {
+      result = Smt.Prover.Valid;
+      failing_proc = None;
+      reason = None;
+      loc = None;
+    }
+  with Proc_invalid (s, result, reason, loc) ->
+    { result; failing_proc = Some s; reason; loc }
 
 let verify ?debug ?timeout ?machine_int program =
   (verify_report ?debug ?timeout ?machine_int program).result

--- a/src/hoare.mli
+++ b/src/hoare.mli
@@ -30,3 +30,17 @@ val verify :
     integers: each arithmetic operation must be proven not to overflow (see
     [safe]/[Arith.in_bounds]), including inside loops and across procedure
     calls. The default reasons over unbounded integers. *)
+
+type report = { result : Smt.Prover.result; failing_proc : string option }
+(** A whole-program verification outcome. [failing_proc] names the first
+    procedure ([main] included, under the name ["main"]) whose body failed to
+    verify, and is [None] iff [result] is [Valid]. *)
+
+val verify_report :
+  ?debug:bool ->
+  ?timeout:float ->
+  ?machine_int:bool ->
+  (Triple.t * Vars.t) list ->
+  report
+(** As {!verify}, but also reports which procedure was rejected. {!verify} is
+    [(verify_report ...).result]. *)

--- a/src/hoare.mli
+++ b/src/hoare.mli
@@ -15,7 +15,12 @@ module Proc_map : sig
   type 'a t
 end
 
-val safe : g_vars:Vars.t -> ?l_vars:Vars.t -> 'a Program.expr -> T.term
+val safe :
+  g_vars:Vars.t ->
+  ?l_vars:Vars.t ->
+  ?loc:Why3.Loc.position ->
+  'a Program.expr ->
+  T.term
 (** [safe e] is the overflow-freedom obligation for [e]: the conjunction of
     [Arith.in_bounds] over every arithmetic result [e] computes. It is [true]
     for expressions built only from literals, variables, and comparisons. *)
@@ -54,12 +59,15 @@ type report = {
   result : Smt.Prover.result;
   failing_proc : string option;
   reason : reason option;
+  loc : Ast.Loc.t option;
 }
 (** A whole-program verification outcome. [failing_proc] names the first
     procedure ([main] included, under the name ["main"]) whose body failed to
     verify, and is [None] iff [result] is [Valid]. [reason] classifies the
     failure when the prover isolated it to one obligation ([None] if it could
-    not, e.g. an internal [Failed]). *)
+    not, e.g. an internal [Failed]). [loc] points at the offending construct,
+    and is [None] for whole-procedure obligations (a plain postcondition) and
+    static rejections. *)
 
 val verify_report :
   ?debug:bool ->

--- a/src/hoare.mli
+++ b/src/hoare.mli
@@ -31,10 +31,35 @@ val verify :
     [safe]/[Arith.in_bounds]), including inside loops and across procedure
     calls. The default reasons over unbounded integers. *)
 
-type report = { result : Smt.Prover.result; failing_proc : string option }
+(** Why a verification obligation failed. Recovered from the failing subgoal's
+    explanation attribute; see {!expl_of_reason} for the human wording. *)
+type reason =
+  | Postcondition
+  | Loop_invariant_init
+  | Loop_invariant_preserved
+  | Loop_variant
+  | Recursive_variant
+  | Call_precondition
+  | Array_bounds
+  | Array_length_nonneg
+  | Nonzero_divisor
+  | No_overflow
+  | Undeclared_write
+[@@deriving sexp_of, compare]
+
+val expl_of_reason : reason -> string
+(** A one-line, user-facing explanation of a {!type-reason}. *)
+
+type report = {
+  result : Smt.Prover.result;
+  failing_proc : string option;
+  reason : reason option;
+}
 (** A whole-program verification outcome. [failing_proc] names the first
     procedure ([main] included, under the name ["main"]) whose body failed to
-    verify, and is [None] iff [result] is [Valid]. *)
+    verify, and is [None] iff [result] is [Valid]. [reason] classifies the
+    failure when the prover isolated it to one obligation ([None] if it could
+    not, e.g. an internal [Failed]). *)
 
 val verify_report :
   ?debug:bool ->

--- a/src/main.ml
+++ b/src/main.ml
@@ -40,15 +40,18 @@ let compile ?(debug = false) ?(verify = true) ?(native_int = false) ~output path
   (if verify then
      match Hoare.verify_report ~machine_int:native_int ast with
      | { result = Smt.Prover.Valid; _ } -> ()
-     | { result = Smt.Prover.Invalid; failing_proc } ->
+     | { result = Smt.Prover.Invalid; failing_proc; reason } ->
          let where =
            match failing_proc with
            | Some p -> Printf.sprintf "procedure '%s': " p
            | None -> ""
          in
-         raise
-           (Verification_failed
-              (where ^ "precondition does not imply postcondition"))
+         let what =
+           match reason with
+           | Some r -> Hoare.expl_of_reason r
+           | None -> "precondition does not imply postcondition"
+         in
+         raise (Verification_failed (where ^ what))
      | { result = Smt.Prover.Failed s; _ } ->
          raise (Verification_failed ("internal failure: " ^ s)));
   let ocaml = Compile.emit ~native_int ast in

--- a/src/main.ml
+++ b/src/main.ml
@@ -12,6 +12,7 @@ let get_ast path =
   List.map Triple.translate ut_ast |> Var_collection.collect
 
 let verify = Hoare.verify
+let verify_report = Hoare.verify_report
 
 let exec path =
   get_ast path |> List.map (fun p -> fst p |> Runtime.to_proc_t) |> Runtime.exec
@@ -37,11 +38,18 @@ let compile ?(debug = false) ?(verify = true) ?(native_int = false) ~output path
     =
   let ast = get_ast path in
   (if verify then
-     match Hoare.verify ~machine_int:native_int ast with
-     | Smt.Prover.Valid -> ()
-     | Smt.Prover.Invalid ->
-         raise (Verification_failed "precondition does not imply postcondition")
-     | Smt.Prover.Failed s ->
+     match Hoare.verify_report ~machine_int:native_int ast with
+     | { result = Smt.Prover.Valid; _ } -> ()
+     | { result = Smt.Prover.Invalid; failing_proc } ->
+         let where =
+           match failing_proc with
+           | Some p -> Printf.sprintf "procedure '%s': " p
+           | None -> ""
+         in
+         raise
+           (Verification_failed
+              (where ^ "precondition does not imply postcondition"))
+     | { result = Smt.Prover.Failed s; _ } ->
          raise (Verification_failed ("internal failure: " ^ s)));
   let ocaml = Compile.emit ~native_int ast in
   if debug then (

--- a/src/main.ml
+++ b/src/main.ml
@@ -7,6 +7,9 @@ let get_ast path =
   let open Stdio in
   let file = In_channel.create path in
   let lexbuf = Lexing.from_channel file in
+  (* Record the filename so source locations attached to the AST (and, through
+     the WLP, to proof obligations) can be printed as [file:line:col]. *)
+  lexbuf.Lexing.lex_curr_p <- { lexbuf.Lexing.lex_curr_p with pos_fname = path };
   let ut_ast = Parser.top Lexer.main lexbuf in
   In_channel.close file;
   List.map Triple.translate ut_ast |> Var_collection.collect
@@ -40,10 +43,15 @@ let compile ?(debug = false) ?(verify = true) ?(native_int = false) ~output path
   (if verify then
      match Hoare.verify_report ~machine_int:native_int ast with
      | { result = Smt.Prover.Valid; _ } -> ()
-     | { result = Smt.Prover.Invalid; failing_proc; reason } ->
+     | { result = Smt.Prover.Invalid; failing_proc; reason; loc } ->
          let where =
            match failing_proc with
            | Some p -> Printf.sprintf "procedure '%s': " p
+           | None -> ""
+         in
+         let at =
+           match loc with
+           | Some l -> Printf.sprintf "%s: " (Ast.Loc.to_string l)
            | None -> ""
          in
          let what =
@@ -51,7 +59,7 @@ let compile ?(debug = false) ?(verify = true) ?(native_int = false) ~output path
            | Some r -> Hoare.expl_of_reason r
            | None -> "precondition does not imply postcondition"
          in
-         raise (Verification_failed (where ^ what))
+         raise (Verification_failed (where ^ at ^ what))
      | { result = Smt.Prover.Failed s; _ } ->
          raise (Verification_failed ("internal failure: " ^ s)));
   let ocaml = Compile.emit ~native_int ast in

--- a/src/main.mli
+++ b/src/main.mli
@@ -18,6 +18,15 @@ val verify :
 (** Verify a parsed program. See {!Hoare.verify} for [machine_int] and the other
     parameters. *)
 
+val verify_report :
+  ?debug:bool ->
+  ?timeout:float ->
+  ?machine_int:bool ->
+  (Triple.t * Vars.t) list ->
+  Hoare.report
+(** As {!verify}, but also reports which procedure was rejected. Backs the
+    [cav verify] CLI so it can name the failing procedure. *)
+
 val exec : string -> int
 (** Parse and interpret the source file at the given path, returning [main]'s
     result. Backs [cav run]. *)

--- a/src/smt/prover.ml
+++ b/src/smt/prover.ml
@@ -75,6 +75,18 @@ let prove timeout base_task vars t =
    caller can build a minimal per-subgoal task before discharging it. Splitting
    here rather than proving the whole conjunction at once is also what lets a
    failure be pinned to a single obligation. *)
+(* First located node in a top-down traversal. A split subgoal has the shape
+   [hypotheses -> obligation]; the obligation's atoms carry the source location
+   (set by the caller on every node) while the [->]/hypotheses do not, so the
+   first location found is the obligation's. *)
+let rec first_loc t =
+  match t.Term.t_loc with
+  | Some _ as l -> l
+  | None ->
+      Term.t_fold
+        (fun acc sub -> match acc with Some _ -> acc | None -> first_loc sub)
+        None t
+
 let split_obligations base_task vars t =
   let goal_id = Decl.create_prsymbol (Ident.id_fresh "goal") in
   let task =
@@ -84,4 +96,5 @@ let split_obligations base_task vars t =
   Trans.apply Split_goal.split_goal_right task
   |> List.map ~f:(fun st ->
       let _, expl, _ = Termcode.goal_expl_task ~root:false st in
-      (Task.task_goal_fmla st, expl))
+      let f = Task.task_goal_fmla st in
+      (f, expl, first_loc f))

--- a/src/smt/prover.ml
+++ b/src/smt/prover.ml
@@ -47,21 +47,41 @@ let result_of_answer ~output (answer : Call_provers.prover_answer) : result =
   | Timeout | OutOfMemory | StepLimitExceeded | HighFailure _ | Failure _ ->
       Failed output
 
-let prove timeout base_task term =
-  let goal_id = Decl.create_prsymbol (Ident.id_fresh "goal") in
-  let task = Task.add_prop_decl base_task Decl.Pgoal goal_id term in
+(* Run Alt-Ergo on a task whose goal is already in place, returning its raw
+   result. Shared by the whole-goal [prove] and the per-obligation [prove_term]. *)
+let run_prover timeout task =
   let limit =
     match timeout with
     | None -> Call_provers.empty_limits
     | Some limit_time ->
         { Call_provers.limit_time; limit_mem = -1; limit_steps = -1 }
   in
-  let result =
-    Driver.prove_task ~limits:limit ~config:main
-      ~command:alt_ergo.Whyconf.command alt_ergo_driver task
-    |> Call_provers.wait_on_call
-  in
+  Driver.prove_task ~limits:limit ~config:main ~command:alt_ergo.Whyconf.command
+    alt_ergo_driver task
+  |> Call_provers.wait_on_call
+
+let prove_term timeout base_task term =
+  let goal_id = Decl.create_prsymbol (Ident.id_fresh "goal") in
+  let task = Task.add_prop_decl base_task Decl.Pgoal goal_id term in
+  let result = run_prover timeout task in
   result_of_answer ~output:result.pr_output result.pr_answer
 
 let prove timeout base_task vars t =
-  Term.t_forall_close vars [] t |> prove timeout base_task
+  Term.t_forall_close vars [] t |> prove_term timeout base_task
+
+(* Split the closed goal into one already-closed subgoal formula per obligation,
+   each paired with its explanation attribute (the string the caller attached
+   via an [expl:] attribute). Purely structural -- no prover is run -- so the
+   caller can build a minimal per-subgoal task before discharging it. Splitting
+   here rather than proving the whole conjunction at once is also what lets a
+   failure be pinned to a single obligation. *)
+let split_obligations base_task vars t =
+  let goal_id = Decl.create_prsymbol (Ident.id_fresh "goal") in
+  let task =
+    Task.add_prop_decl base_task Decl.Pgoal goal_id
+      (Term.t_forall_close vars [] t)
+  in
+  Trans.apply Split_goal.split_goal_right task
+  |> List.map ~f:(fun st ->
+      let _, expl, _ = Termcode.goal_expl_task ~root:false st in
+      (Task.task_goal_fmla st, expl))

--- a/src/smt/prover.mli
+++ b/src/smt/prover.mli
@@ -22,3 +22,15 @@ val prove :
 (** [prove timeout task vars goal] universally closes [goal] over [vars], adds
     it to [task] as the goal, and runs Alt-Ergo. [timeout] is a per-goal time
     limit in seconds ([None] for unlimited). *)
+
+val prove_term : float option -> Task.task -> Term.term -> result
+(** As {!prove} but for a term that is already the goal (no universal closure).
+    Used to discharge an individual split obligation. *)
+
+val split_obligations :
+  Task.task -> Term.vsymbol list -> Term.term -> (Term.term * string) list
+(** [split_obligations task vars goal] closes [goal] over [vars] and splits it
+    with [split_goal_right] into one already-closed subgoal per obligation, each
+    paired with its explanation attribute. No prover is run: the caller builds a
+    suitable per-subgoal task (e.g. minimising theory inclusion) and discharges
+    it with {!prove_term}. *)

--- a/src/smt/prover.mli
+++ b/src/smt/prover.mli
@@ -28,9 +28,13 @@ val prove_term : float option -> Task.task -> Term.term -> result
     Used to discharge an individual split obligation. *)
 
 val split_obligations :
-  Task.task -> Term.vsymbol list -> Term.term -> (Term.term * string) list
+  Task.task ->
+  Term.vsymbol list ->
+  Term.term ->
+  (Term.term * string * Loc.position option) list
 (** [split_obligations task vars goal] closes [goal] over [vars] and splits it
     with [split_goal_right] into one already-closed subgoal per obligation, each
-    paired with its explanation attribute. No prover is run: the caller builds a
-    suitable per-subgoal task (e.g. minimising theory inclusion) and discharges
-    it with {!prove_term}. *)
+    paired with its explanation attribute and its source location (the first
+    located node in the subgoal, [None] if the obligation was untagged). No
+    prover is run: the caller builds a suitable per-subgoal task (e.g.
+    minimising theory inclusion) and discharges it with {!prove_term}. *)

--- a/test/fuzz/fuzz.ml
+++ b/test/fuzz/fuzz.ml
@@ -472,6 +472,7 @@ let rec logic_to_cav = function
 
 let rec cmd_to_cav c =
   match c with
+  | Program.Located (_, c) -> cmd_to_cav c
   | Program.Assgn (x, e) -> Printf.sprintf "%s <- %s" x (expr_to_cav e)
   | Program.Let (x, e) -> Printf.sprintf "%s <- %s" x (expr_to_cav e)
   | Program.Seq (a, b) -> Printf.sprintf "%s;\n%s" (cmd_to_cav a) (cmd_to_cav b)

--- a/test/integration.ml
+++ b/test/integration.ml
@@ -240,6 +240,53 @@ let%test_unit "Main.verify_report names main when main fails" =
 let%test_unit "Main.verify_report reports no procedure on success" =
   check_failing_proc "verify_true_if.cav" None
 
+(* A rejected program is classified by *why* the obligation failed. Each fixture
+   below is engineered to fail exactly one kind of obligation, so the reported
+   reason pins down the fault. *)
+let check_reason ?(machine_int = false) path expect =
+  [%test_result: Hoare.reason option]
+    (Main.verify_report ~debug ~machine_int ?timeout:(Some 5.)
+       (Main.get_ast path))
+      .reason
+    ~expect:(Some expect)
+
+let%test_unit "reason: postcondition" =
+  check_reason "verify_false.cav" Postcondition
+
+let%test_unit "reason: procedure violates its own ensures" =
+  check_reason "verify_false_proc_ensures.cav" Postcondition
+
+let%test_unit "reason: callee precondition" =
+  check_reason "verify_false_proc_requires.cav" Call_precondition
+
+let%test_unit "reason: divisor may be zero" =
+  check_reason "verify_false_div_by_zero.cav" Nonzero_divisor
+
+let%test_unit "reason: array index out of bounds (write)" =
+  check_reason "verify_false_array_write_oob.cav" Array_bounds
+
+let%test_unit "reason: array index out of bounds (read)" =
+  check_reason "verify_false_array_read_oob.cav" Array_bounds
+
+let%test_unit "reason: array length negative" =
+  check_reason "verify_false_array_negative_length.cav" Array_length_nonneg
+
+let%test_unit "reason: loop invariant on entry" =
+  check_reason "verify_false_inv_entry.cav" Loop_invariant_init
+
+let%test_unit "reason: loop variant does not decrease" =
+  check_reason "verify_false_variant.cav" Loop_variant
+
+let%test_unit "reason: recursive variant does not decrease" =
+  check_reason "verify_false_recursion.cav" Recursive_variant
+
+let%test_unit "reason: undeclared write" =
+  check_reason "verify_false_writes_undeclared.cav" Undeclared_write
+
+(* Overflow-freedom is only an obligation under machine-integer verification. *)
+let%test_unit "reason: arithmetic may overflow (machine int)" =
+  check_reason ~machine_int:true "verify_boundary_overflow.cav" No_overflow
+
 (* A provided variant that does not decrease (here the measure [i] increases)
    is rejected even though the loop does terminate: the given measure fails to
    prove it. *)

--- a/test/integration.ml
+++ b/test/integration.ml
@@ -221,6 +221,25 @@ let%test_unit "Main.verify true variant with array measure" =
 
 let%test_unit "Main.verify false" = check_verify "verify_false.cav" Invalid
 
+(* A rejected program reports which procedure failed to verify (main included,
+   under the name "main"). *)
+let check_failing_proc path expect =
+  [%test_result: string option]
+    (Main.verify_report ~debug ?timeout:(Some 5.) (Main.get_ast path))
+      .failing_proc ~expect
+
+let%test_unit "Main.verify_report names the failing procedure" =
+  check_failing_proc "verify_false_proc_ensures.cav" (Some "f")
+
+let%test_unit "Main.verify_report names an undeclared-writes procedure" =
+  check_failing_proc "verify_false_writes_undeclared.cav" (Some "f")
+
+let%test_unit "Main.verify_report names main when main fails" =
+  check_failing_proc "verify_false.cav" (Some "main")
+
+let%test_unit "Main.verify_report reports no procedure on success" =
+  check_failing_proc "verify_true_if.cav" None
+
 (* A provided variant that does not decrease (here the measure [i] increases)
    is rejected even though the loop does terminate: the given measure fails to
    prove it. *)

--- a/test/integration.ml
+++ b/test/integration.ml
@@ -287,6 +287,30 @@ let%test_unit "reason: undeclared write" =
 let%test_unit "reason: arithmetic may overflow (machine int)" =
   check_reason ~machine_int:true "verify_boundary_overflow.cav" No_overflow
 
+(* A construct-level failure points at the source line of the offending command;
+   a whole-procedure obligation (a plain postcondition) carries no location. *)
+let loc_line path =
+  match
+    (Main.verify_report ~debug ?timeout:(Some 5.) (Main.get_ast path)).loc
+  with
+  | Some (l : Main.Ast.Loc.t) -> Some l.line
+  | None -> None
+
+let check_loc_line path expect =
+  [%test_result: int option] (loc_line path) ~expect
+
+let%test_unit "location: divide-by-zero points at the division's line" =
+  check_loc_line "verify_false_div_by_zero.cav" (Some 2)
+
+let%test_unit "location: out-of-bounds write points at the write's line" =
+  check_loc_line "verify_false_array_write_oob.cav" (Some 3)
+
+let%test_unit "location: recursive variant points at the call's line" =
+  check_loc_line "verify_false_recursion.cav" (Some 7)
+
+let%test_unit "location: a plain postcondition has no location" =
+  check_loc_line "verify_false.cav" None
+
 (* A provided variant that does not decrease (here the measure [i] increases)
    is rejected even though the loop does terminate: the given measure fails to
    prove it. *)


### PR DESCRIPTION
## Native compilation backend (Option B: transpile to OCaml)

Adds a `cav compile` path that turns a Cavalry program into a **standalone native
executable**, rather than only interpreting it via `cav run`. The approach
(Option B in the design discussion) reuses the entire existing front-end
(parse → `Program.translate_cmd` → `Var_collection.collect`) and transpiles the
typed AST to OCaml source, which is then built into a native binary by
`ocamlfind ocamlopt`.

> This PR is the umbrella for the whole feature and will grow to cover all
> milestones below. It is opened early so the design and the correctness
> reasoning can be reviewed incrementally, commit by commit.

### Why this design

Cavalry constructs map almost 1:1 onto OCaml, so a codegen backend is small and
the output is real native code with no tree-walking overhead — while sidestepping
the GADT-marshalling awkwardness of bundling the interpreter and the large
surface of a C/LLVM backend.

### Correctness is the point of this feature

Cavalry exists to *verify* programs, so the compiler treats verification as a
first-class concern along two axes:

1. **Codegen must preserve the *verified* semantics.** `Hoare.verify` proves
   properties over Why3's **unbounded** mathematical integers, but OCaml native
   `int` is 63-bit and wraps — the exact hazard `Ast.Runtime`'s `check_overflow`
   flag already documents. A naive transpile to `+`/`-`/`*` could produce results
   the proof never sanctioned. **We therefore emit arbitrary-precision Zarith
   arithmetic**, so the compiled binary's integer model coincides with the model
   the proof is about.
2. **Only compile what verifies** (planned, M5): `cav compile` will run
   `Hoare.verify` before emitting and refuse to produce a binary for a program
   that violates its own spec, with a `--no-verify` escape hatch.

The interpreter's two-store model (persistent globals vs. shadowing locals) is
reproduced exactly using three disjoint prefixed OCaml namespaces — `g_` globals
(mutable refs), `l_` locals (formals + `let`-bindings), `p_` procedures — so a
formal `a` and a global `a` remain the distinct cells they are in `Runtime`, and
no program name can collide with an OCaml keyword. Read resolution is
local-before-global, matching `Runtime.find_var`.

### Milestones

- [x] **M1 — straight-line + arithmetic.** `Compile.emit`; `Assgn`/`Let`/`Seq`/
  `Print`/`IntExpr`, all arithmetic/comparison exprs, Zarith integers.
- [x] **M2 — control flow.** `If`/`While`; lexical scope resolution
  (in-scope let-locals vs. assigned globals).
- [x] **M3 — procedures.** Functions, formals as locals, `Assgn`-always-global,
  `g_`/`l_`/`p_` namespacing, source-order emission.
- [ ] **M4 — CLI + build.** `cav compile` subcommand (`-o`, `--debug`), shell out
  to `ocamlfind ocamlopt -package zarith`, add `zarith` to `dune-project`.
- [ ] **M5 — verify gate.** Run `Hoare.verify` before emit; `--no-verify`;
  optional `--native-int` (documented as fast-but-unsound-on-overflow).
- [ ] **M6 — end-to-end tests.** Fold the differential check (compiled binary
  stdout == `cav run` stdout) into `dune runtest`; add overflow-fidelity and
  verify-gate tests.

### Verification so far

Golden inline tests in `test/compile.ml` cover emission of each construct. Beyond
those, the emitted OCaml has been compiled with Zarith and run against `cav run`
for every runnable fixture — **11/11 match**, including all six procedure
fixtures (`fib`=34 across 9 shared-global mutations, `read_global`=101, …),
control flow (`exec_nested_while`=9), and straight-line cases. This differential
check becomes an automated test in M6.

Design notes and the running milestone checklist live in `PLAN.md` (gitignored).
