### PR TITLE
verify: exit non-zero when a program fails to verify

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -23,8 +23,11 @@ let verify debug machine_int source_file =
         | Some r -> Hoare.expl_of_reason r
         | None -> "precondition does not imply postcondition"
       in
-      Printf.printf "verification unsuccessful%s%s: %s\n" where at what
-  | { result = Failed s; _ } -> Printf.printf "internal failure: %s\n" s
+      Printf.printf "verification unsuccessful%s%s: %s\n" where at what;
+      exit 1
+  | { result = Failed s; _ } ->
+      Printf.printf "internal failure: %s\n" s;
+      exit 2
 
 let compile debug no_verify native_int output source_file =
   let output =


### PR DESCRIPTION
`cav verify` printed `verification unsuccessful` but still exited `0`, so scripts and CI couldn't distinguish success from failure by exit status — they had to parse stdout (as the snippet-verification step in #16 does).

## Change

`bin/main.ml`: the `verify` command now exits
- `0` on a successful proof (unchanged),
- `1` when the program does not verify,
- `2` on an internal prover failure.

This mirrors the `exit 1`-on-failure the `compile` command already uses for its verification gate.

## Follow-up

Once this lands, the `Verify README example programs` CI step added in #16 can be simplified to rely on exit status instead of grepping `cav verify` output (the failing-spec example would just expect a non-zero exit).