### PR TITLE
feat: compound boolean guards and one-armed if

### DIFF
--- a/src/ast/parse/program.mly
+++ b/src/ast/parse/program.mly
@@ -98,6 +98,12 @@ expr:
       { UGt (e0, e1) }
   | e0 = expr GEQ e1 = expr
       { UGeq (e0, e1) }
+  | e0 = expr AND e1 = expr
+      { UAnd (e0, e1) }
+  | e0 = expr OR e1 = expr
+      { UOr (e0, e1) }
+  | NOT e = expr
+      { UNot (e) }
   | LPAREN e = expr RPAREN
       { ( e ) }
 ;

--- a/src/ast/parse/program.mly
+++ b/src/ast/parse/program.mly
@@ -56,6 +56,12 @@ command_desc:
       { USeq (c0, c1) }
   | IF e = expr THEN c0 = command ELSE c1 = command END
       { UIf (e, c0, c1) }
+  (* One-armed [if]: an absent [else] is a no-op. Desugar it to an [else]
+     branch that evaluates the trivial expression [0] and discards it -- a bare
+     expression is already a valid (effect-free) command, so this needs no new
+     AST node and its WLP collapses to the identity. *)
+  | IF e = expr THEN c0 = command END
+      { UIf (e, c0, UInt 0) }
   | WHILE e = expr DO INVARIANT LBRACE inv = logic_expr RBRACE c = command END
       { UWhile (inv, None, e, c) }
   | WHILE e = expr DO INVARIANT LBRACE inv = logic_expr RBRACE VARIANT LBRACE m = arith_expr RBRACE c = command END

--- a/src/ast/program.ml
+++ b/src/ast/program.ml
@@ -15,6 +15,9 @@ type _ expr =
   | Leq : int expr * int expr -> bool expr
   | Gt : int expr * int expr -> bool expr
   | Geq : int expr * int expr -> bool expr
+  | And : bool expr * bool expr -> bool expr
+  | Or : bool expr * bool expr -> bool expr
+  | Not : bool expr -> bool expr
   | Plus : int expr * int expr -> int expr
   | Sub : int expr * int expr -> int expr
   | Mul : int expr * int expr -> int expr
@@ -58,6 +61,9 @@ type ut_expr =
   | ULeq of ut_expr * ut_expr
   | UGt of ut_expr * ut_expr
   | UGeq of ut_expr * ut_expr
+  | UAnd of ut_expr * ut_expr
+  | UOr of ut_expr * ut_expr
+  | UNot of ut_expr
   | UPlus of ut_expr * ut_expr
   | USub of ut_expr * ut_expr
   | UMul of ut_expr * ut_expr
@@ -92,6 +98,9 @@ and t_bool_expr = function
   | ULeq (a, b) -> Leq (t_int_expr a, t_int_expr b)
   | UGt (a, b) -> Gt (t_int_expr a, t_int_expr b)
   | UGeq (a, b) -> Geq (t_int_expr a, t_int_expr b)
+  | UAnd (a, b) -> And (t_bool_expr a, t_bool_expr b)
+  | UOr (a, b) -> Or (t_bool_expr a, t_bool_expr b)
+  | UNot a -> Not (t_bool_expr a)
   | e -> raise (TypeError (show_ut_expr e))
 
 and expr_to_cmd = function

--- a/src/ast/program.mli
+++ b/src/ast/program.mli
@@ -27,6 +27,9 @@ type _ expr =
   | Leq : int expr * int expr -> bool expr
   | Gt : int expr * int expr -> bool expr
   | Geq : int expr * int expr -> bool expr
+  | And : bool expr * bool expr -> bool expr
+  | Or : bool expr * bool expr -> bool expr
+  | Not : bool expr -> bool expr
   | Plus : int expr * int expr -> int expr
   | Sub : int expr * int expr -> int expr
   | Mul : int expr * int expr -> int expr
@@ -75,6 +78,9 @@ type ut_expr =
   | ULeq of ut_expr * ut_expr
   | UGt of ut_expr * ut_expr
   | UGeq of ut_expr * ut_expr
+  | UAnd of ut_expr * ut_expr
+  | UOr of ut_expr * ut_expr
+  | UNot of ut_expr
   | UPlus of ut_expr * ut_expr
   | USub of ut_expr * ut_expr
   | UMul of ut_expr * ut_expr

--- a/src/ast/runtime.ml
+++ b/src/ast/runtime.ml
@@ -149,6 +149,10 @@ let rec exec_expr : type a. Runtime.t -> a expr -> a =
   | Geq (a, b) ->
       let v1 = exec_expr r a in
       v1 >= exec_expr r b
+  (* Short-circuiting, matching OCaml's [&&]/[||] and the compiled backend. *)
+  | And (a, b) -> exec_expr r a && exec_expr r b
+  | Or (a, b) -> exec_expr r a || exec_expr r b
+  | Not a -> not (exec_expr r a)
 
 and exec_cmd ?(fuel = ref max_int) r c : int * Runtime.t =
   let exec_cmd r c = exec_cmd ~fuel r c in

--- a/src/ast/var_collection.ml
+++ b/src/ast/var_collection.ml
@@ -64,6 +64,9 @@ let collect_program c =
     | Gt (e, e')
     | Geq (e, e') ->
         Str_set.union (collect_expr e) (collect_expr e')
+    | And (e, e') | Or (e, e') ->
+        Str_set.union (collect_expr e) (collect_expr e')
+    | Not e -> collect_expr e
     | Get (a, e) -> Str_set.add a (collect_expr e)
     | Len a -> Str_set.singleton a
   in
@@ -138,6 +141,8 @@ let arrays_program c =
     | Gt (a, b)
     | Geq (a, b) ->
         Str_set.union (expr a) (expr b)
+    | And (a, b) | Or (a, b) -> Str_set.union (expr a) (expr b)
+    | Not a -> expr a
   in
   let rec cmd = function
     | Located (_, c) -> cmd c

--- a/src/compile.ml
+++ b/src/compile.ml
@@ -141,6 +141,8 @@ let rec arrays_expr : type a. a expr -> Str_set.t = function
   | Gt (a, b)
   | Geq (a, b) ->
       Str_set.union (arrays_expr a) (arrays_expr b)
+  | And (a, b) | Or (a, b) -> Str_set.union (arrays_expr a) (arrays_expr b)
+  | Not a -> arrays_expr a
 
 let rec arrays = function
   | Located (_, c) -> arrays c
@@ -188,14 +190,22 @@ let emit_bool ~ops ~locals (e : bool expr) : string =
     Printf.sprintf "(%s %s %s)" op (emit_int ~ops ~locals a)
       (emit_int ~ops ~locals b)
   in
-  match e with
-  | Value (Bool b) -> string_of_bool b
-  | Eq (a, b) -> cmp ops.eq a b
-  | Neq (a, b) -> Printf.sprintf "(not %s)" (cmp ops.eq a b)
-  | Lt (a, b) -> cmp ops.lt a b
-  | Leq (a, b) -> cmp ops.leq a b
-  | Gt (a, b) -> cmp ops.gt a b
-  | Geq (a, b) -> cmp ops.geq a b
+  (* [go] is explicitly recursive because [&&]/[||]/[!] nest over boolean
+     operands, unlike the flat comparisons. *)
+  let rec go (e : bool expr) : string =
+    match e with
+    | Value (Bool b) -> string_of_bool b
+    | Eq (a, b) -> cmp ops.eq a b
+    | Neq (a, b) -> Printf.sprintf "(not %s)" (cmp ops.eq a b)
+    | Lt (a, b) -> cmp ops.lt a b
+    | Leq (a, b) -> cmp ops.leq a b
+    | Gt (a, b) -> cmp ops.gt a b
+    | Geq (a, b) -> cmp ops.geq a b
+    | And (a, b) -> Printf.sprintf "(%s && %s)" (go a) (go b)
+    | Or (a, b) -> Printf.sprintf "(%s || %s)" (go a) (go b)
+    | Not a -> Printf.sprintf "(not %s)" (go a)
+  in
+  go e
 
 (* Flatten the (possibly unbalanced) [Seq] tree into left-to-right statement
    order, so a [Let] can scope over everything sequenced after it. *)

--- a/src/hoare.ml
+++ b/src/hoare.ml
@@ -123,6 +123,13 @@ let rec expr_to_term : type a.
   | Leq (e, e') -> leq (f e) (f e')
   | Gt (e, e') -> gt (f e) (f e')
   | Geq (e, e') -> geq (f e) (f e')
+  (* [f] is monomorphised to [int expr] by the arithmetic arms; the boolean
+     connectives recurse through the polymorphic [expr_to_term] directly. *)
+  | And (e, e') ->
+      T.t_and (expr_to_term ~g_vars ?l_vars e) (expr_to_term ~g_vars ?l_vars e')
+  | Or (e, e') ->
+      T.t_or (expr_to_term ~g_vars ?l_vars e) (expr_to_term ~g_vars ?l_vars e')
+  | Not e -> T.t_not (expr_to_term ~g_vars ?l_vars e)
   | Plus (e, e') -> plus (f e) (f e')
   | Sub (e, e') -> sub (f e) (f e')
   | Mul (e, e') -> mul (f e) (f e')
@@ -179,6 +186,20 @@ let rec safe : type a.
   | Len _ -> T.t_true
   | Eq (a, b) | Neq (a, b) | Lt (a, b) | Leq (a, b) | Gt (a, b) | Geq (a, b) ->
       T.t_and_simp (self a) (self b)
+  (* [&&]/[||] short-circuit (see [Runtime.exec_expr] and the compiled backend),
+     so the second operand is only evaluated -- and hence only need be safe --
+     when the first has the value that reaches it. [self] is monomorphic
+     ([int expr]); recurse into boolean operands through the polymorphic [safe]
+     directly. *)
+  | And (a, b) ->
+      let self = safe ~g_vars ?l_vars ?loc in
+      T.t_and_simp (self a)
+        (T.t_implies_simp (expr_to_term ~g_vars ?l_vars a) (self b))
+  | Or (a, b) ->
+      let self = safe ~g_vars ?l_vars ?loc in
+      T.t_and_simp (self a)
+        (T.t_implies_simp (T.t_not (expr_to_term ~g_vars ?l_vars a)) (self b))
+  | Not a -> safe ~g_vars ?l_vars ?loc a
 
 (* Well-definedness obligation for an expression: the conjunction of
    [divisor <> 0] over every [Div]/[Mod] node it contains, and
@@ -213,6 +234,20 @@ let rec defined : type a.
   | Len _ -> T.t_true
   | Eq (a, b) | Neq (a, b) | Lt (a, b) | Leq (a, b) | Gt (a, b) | Geq (a, b) ->
       T.t_and_simp (self a) (self b)
+  (* [&&]/[||] short-circuit, so the second operand's well-definedness
+     ([a\[i\]] in bounds, non-zero divisor) is only required when the first
+     operand's value reaches it. This is what lets [i < n && a[i] != x] verify:
+     [a[i]] need not be in bounds when [i < n] is false. [self] is monomorphic
+     ([int expr]); recurse into boolean operands through [defined] directly. *)
+  | And (a, b) ->
+      let self = defined ~g_vars ?l_vars ?loc in
+      T.t_and_simp (self a)
+        (T.t_implies_simp (expr_to_term ~g_vars ?l_vars a) (self b))
+  | Or (a, b) ->
+      let self = defined ~g_vars ?l_vars ?loc in
+      T.t_and_simp (self a)
+        (T.t_implies_simp (T.t_not (expr_to_term ~g_vars ?l_vars a)) (self b))
+  | Not a -> defined ~g_vars ?l_vars ?loc a
 
 module Proc_map = Map.Make (String)
 

--- a/test/compile.ml
+++ b/test/compile.ml
@@ -63,6 +63,23 @@ let%test_unit "Compile.emit - if compiles both branches" =
   List.iter [ "(if "; "Z.lt"; "then"; "else" ] ~f:(fun substring ->
       [%test_pred: string] (contains ~substring) out)
 
+let%test_unit "Compile.emit - boolean connectives use short-circuit operators" =
+  (* if (x < 1 || x > 9) && !(x = 5) then 1 else 0 end -- the connectives must
+     emit OCaml's short-circuiting [&&]/[||]/[not], not a strict conjunction. *)
+  let body =
+    If
+      ( And
+          ( Or
+              ( Lt (Value (VarInst "x"), Value (Int 1)),
+                Gt (Value (VarInst "x"), Value (Int 9)) ),
+            Not (Eq (Value (VarInst "x"), Value (Int 5))) ),
+        IntExpr (Value (Int 1)),
+        IntExpr (Value (Int 0)) )
+  in
+  let out = emit_main body in
+  List.iter [ "&&"; "||"; "not" ] ~f:(fun substring ->
+      [%test_pred: string] (contains ~substring) out)
+
 let%test_unit "Compile.emit - while emits a Zarith-guarded loop" =
   (* while i < 10 do invariant { true } i := i + 1 end *)
   let body =

--- a/test/dune
+++ b/test/dune
@@ -4,6 +4,8 @@
  (inline_tests
   (deps
    exec_if.cav
+   exec_short_circuit.cav
+   verify_true_search.cav
    exec_comment.cav
    exec_while.cav
    exec_proc.cav

--- a/test/dune
+++ b/test/dune
@@ -4,8 +4,10 @@
  (inline_tests
   (deps
    exec_if.cav
+   exec_if_noelse.cav
    exec_short_circuit.cav
    verify_true_search.cav
+   verify_true_if_noelse.cav
    exec_comment.cav
    exec_while.cav
    exec_proc.cav

--- a/test/exec_if_noelse.cav
+++ b/test/exec_if_noelse.cav
@@ -1,0 +1,12 @@
+// One-armed if at runtime: the first guard is taken (x becomes 5), the second
+// is skipped (its absent else is a no-op), so the result is 5.
+{ true }
+x := 0;
+if 1 = 1 then
+  x := x + 5
+end;
+if 1 = 2 then
+  x := x + 100
+end;
+x
+{ true }

--- a/test/exec_short_circuit.cav
+++ b/test/exec_short_circuit.cav
@@ -1,0 +1,20 @@
+// && and || short-circuit at runtime: the out-of-bounds read [a[i]] (i = 3,
+// len = 3) is never evaluated because its guard is already decided, so the run
+// does not raise. First branch: 3 < 3 is false -> else, x = 2. Second: 3 >= 3
+// is true -> y = 30. Result 2 + 30 = 32.
+{ true }
+a := array(3);
+a[0] := 5;
+i := 3;
+if i < len(a) && a[i] = 5 then
+  x := 1
+else
+  x := 2
+end;
+if i >= len(a) || a[i] = 99 then
+  y := 30
+else
+  y := 40
+end;
+x + y
+{ true }

--- a/test/fuzz/fuzz.ml
+++ b/test/fuzz/fuzz.ml
@@ -422,6 +422,13 @@ let rec expr_to_cav : type a. a Program.expr -> string =
   | Program.Leq (a, b) -> bin "<=" a b
   | Program.Gt (a, b) -> bin ">" a b
   | Program.Geq (a, b) -> bin ">=" a b
+  (* [bin] is monomorphised to [int expr] operands; the boolean connectives
+     recurse through the polymorphic [expr_to_cav] directly. *)
+  | Program.And (a, b) ->
+      Printf.sprintf "(%s && %s)" (expr_to_cav a) (expr_to_cav b)
+  | Program.Or (a, b) ->
+      Printf.sprintf "(%s || %s)" (expr_to_cav a) (expr_to_cav b)
+  | Program.Not a -> Printf.sprintf "(! %s)" (expr_to_cav a)
   | Program.Get (a, i) -> Printf.sprintf "%s[%s]" a (expr_to_cav i)
   | Program.Len a -> Printf.sprintf "len(%s)" a
 

--- a/test/integration.ml
+++ b/test/integration.ml
@@ -14,6 +14,11 @@ let check_verify path expect =
 let%test_unit "Main.exec if" =
   [%test_result: int] (Main.exec "exec_if.cav") ~expect:182
 
+(* [&&]/[||] short-circuit at runtime, so the out-of-bounds read guarded by a
+   decided condition is never evaluated and the run does not raise: 2 + 30. *)
+let%test_unit "Main.exec short-circuit guards" =
+  [%test_result: int] (Main.exec "exec_short_circuit.cav") ~expect:32
+
 (* [//] line comments are stripped by the lexer, so a program peppered with
    them evaluates identically to exec_if.cav: 2 + 60 * 3 = 182. *)
 let%test_unit "Main.exec line comments" =
@@ -69,6 +74,12 @@ let%test_unit "Main.exec unbound raises" =
 (* ===== verify: expected Valid ===== *)
 
 let%test_unit "Main.verify true if" = check_verify "verify_true_if.cav" Valid
+
+(* Compound guard with a short-circuiting [&&]: [a[i]] need only be in bounds
+   when [i < n] holds, which is exactly what the short-circuit definedness
+   obligation grants. The headline case for compound boolean guards. *)
+let%test_unit "Main.verify true linear search" =
+  check_verify "verify_true_search.cav" Valid
 
 let%test_unit "Main.verify true while" =
   check_verify "verify_true_while.cav" Valid

--- a/test/integration.ml
+++ b/test/integration.ml
@@ -14,6 +14,11 @@ let check_verify path expect =
 let%test_unit "Main.exec if" =
   [%test_result: int] (Main.exec "exec_if.cav") ~expect:182
 
+(* One-armed [if]: the first guard is taken, the second is skipped (its absent
+   [else] is a no-op), so x = 5. *)
+let%test_unit "Main.exec one-armed if" =
+  [%test_result: int] (Main.exec "exec_if_noelse.cav") ~expect:5
+
 (* [&&]/[||] short-circuit at runtime, so the out-of-bounds read guarded by a
    decided condition is never evaluated and the run does not raise: 2 + 30. *)
 let%test_unit "Main.exec short-circuit guards" =
@@ -74,6 +79,11 @@ let%test_unit "Main.exec unbound raises" =
 (* ===== verify: expected Valid ===== *)
 
 let%test_unit "Main.verify true if" = check_verify "verify_true_if.cav" Valid
+
+(* One-armed [if]: the implicit (empty) else preserves the state, so the
+   postcondition holds on the guard-false path. *)
+let%test_unit "Main.verify true one-armed if" =
+  check_verify "verify_true_if_noelse.cav" Valid
 
 (* Compound guard with a short-circuiting [&&]: [a[i]] need only be in bounds
    when [i < n] holds, which is exactly what the short-circuit definedness

--- a/test/verify_true_if_noelse.cav
+++ b/test/verify_true_if_noelse.cav
@@ -1,0 +1,7 @@
+// One-armed if: an absent else is a no-op, so when the guard is false the
+// state is unchanged and the postcondition still holds.
+{ x = 7 }
+if x < 0 then
+  x := 0
+end
+{ x = 7 }

--- a/test/verify_true_search.cav
+++ b/test/verify_true_search.cav
@@ -1,0 +1,10 @@
+// Linear search: the guard [a[i] != x] is only evaluated when [i < n]
+// (short-circuiting &&), so [a[i]] stays in bounds even when [i = n].
+{ n >= 0 && n <= len(a) }
+i := 0;
+while i < n && a[i] != x do
+  invariant { 0 <= i && i <= n && n <= len(a) }
+  variant { n - i }
+  i := i + 1
+end
+{ 0 <= i && i <= n }


### PR DESCRIPTION
Two expressiveness additions to the program language (roadmap phases 1 and 2), landed as separate commits.

## Compound boolean guards (`&&`, `||`, `!`)

`if` and `while` guards could previously only be a single comparison or a bool literal — `t_bool_expr` had no boolean connectives, so a loop like `while i < n && a[i] != x do ...` was unparseable. The logic language already had `&&`/`||`/`!`; this brings the program language to parity.

`And`/`Or`/`Not` are added to the `bool expr` GADT (and `UAnd`/`UOr`/`UNot` to the untyped AST), and threaded through the parser (tokens and precedence already existed for the logic grammar), the interpreter, the Zarith/native compiler, and variable collection.

The verification obligations are **short-circuit-aware**, matching the `&&`/`||` semantics the interpreter and compiled binary already use: the second operand's definedness (array bounds, non-zero divisor) and overflow-safety obligations are only imposed under the first operand's controlling value. That is what lets linear search verify — `a[i]` need not be in bounds when `i < n` is false. The value-level translation stays a plain logical `t_and`/`t_or`, which is sound because Why3's array `get` is total.

## One-armed `if`

`if c then ... end` (no `else`) now parses, desugaring the absent branch to the trivial no-op expression `0`. A bare expression is already a valid, effect-free command, so this needs no new AST node — the interpreter evaluates and discards it, and its WLP collapses to the identity. The one-armed and two-armed forms are LR(1)-disambiguated by the token after the branch (`end` vs `else`), so the grammar stays conflict-free.

## Testing

`dune build`, `dune build @fmt`, `dune runtest`, and `dune build @doc` all pass. Exercised end-to-end through `run`, `verify`, and native `compile`:

- linear search verifies (short-circuit definedness), and the compiled binary short-circuits at runtime (a broken `&&` would crash on the out-of-bounds read);
- under `--machine-int`, a guarded overflow verifies while an unguarded one is still rejected.

New fixtures: `verify_true_search`, `exec_short_circuit`, `exec_if_noelse`, `verify_true_if_noelse`, plus a compiler substring test for the connectives.