### PR TITLE
feat: first-class boolean variables (milestone 4)

### DIFF
--- a/src/ast/logic.ml
+++ b/src/ast/logic.ml
@@ -15,6 +15,7 @@ type arith_expr =
 
 type logic_expr =
   | Bool of bool
+  | BoolVar of string (* a boolean program variable as a proposition *)
   | Not of logic_expr
   | And of logic_expr * logic_expr
   | Or of logic_expr * logic_expr
@@ -68,14 +69,29 @@ let rec translate_term ~g_vars ?l_vars ?(bound = Vars.empty) e =
     close [ vs ] []
       (translate_term ~g_vars ?l_vars ~bound:(Vars.add x vs bound) body)
   in
+  (* Whether a translated term is boolean-sorted (a boolean variable), so [=]/
+     [!=] over it use Why3's polymorphic equality rather than the integer
+     comparison predicate. *)
+  let is_bool_term t =
+    match t.T.t_ty with
+    | Some ty -> Why3.Ty.ty_equal ty Why3.Ty.ty_bool
+    | None -> false
+  in
   e |> function
   | Bool b -> if b then T.t_true else T.t_false
+  (* A boolean program variable asserted as a proposition: [v = True]. *)
+  | BoolVar x ->
+      T.t_equ (T.t_var (resolve ~g_vars ?l_vars ~bound x)) T.t_bool_true
   | Not e -> T.t_not (f_t e)
   | And (e0, e1) -> T.t_and (f_t e0) (f_t e1)
   | Or (e0, e1) -> T.t_or (f_t e0) (f_t e1)
   | Impl (e0, e1) -> T.t_implies (f_t e0) (f_t e1)
-  | Eq (e0, e1) -> Arith.eq (f_a e0) (f_a e1)
-  | Neq (e0, e1) -> Arith.neq (f_a e0) (f_a e1)
+  | Eq (e0, e1) ->
+      let a = f_a e0 and b = f_a e1 in
+      if is_bool_term a then T.t_equ a b else Arith.eq a b
+  | Neq (e0, e1) ->
+      let a = f_a e0 and b = f_a e1 in
+      if is_bool_term a then T.t_not (T.t_equ a b) else Arith.neq a b
   | Lt (e0, e1) -> Arith.lt (f_a e0) (f_a e1)
   | Leq (e0, e1) -> Arith.leq (f_a e0) (f_a e1)
   | Gt (e0, e1) -> Arith.gt (f_a e0) (f_a e1)

--- a/src/ast/logic.mli
+++ b/src/ast/logic.mli
@@ -29,6 +29,8 @@ type arith_expr =
     {!arith_expr} comparisons, closed under the connectives and quantifiers. *)
 type logic_expr =
   | Bool of bool
+  | BoolVar of string
+      (** a boolean program variable asserted as a proposition *)
   | Not of logic_expr
   | And of logic_expr * logic_expr
   | Or of logic_expr * logic_expr

--- a/src/ast/parse/logic.mly
+++ b/src/ast/parse/logic.mly
@@ -7,6 +7,8 @@
 %public logic_expr:
   | b = BOOL
       { Bool (b) }
+  | v = VAR
+      { Ast.Logic.BoolVar (v) }
   | NOT e = logic_expr
       { Not (e) }
   | e0 = logic_expr AND e1 = logic_expr

--- a/src/ast/program.ml
+++ b/src/ast/program.ml
@@ -41,7 +41,7 @@ type cmd =
   | Seq of cmd * cmd
   | Assgn of string * anyexpr
   | Let of string * anyexpr
-  | Proc of string * int expr list
+  | Proc of string * anyexpr list
   | If of bool expr * cmd * cmd
   | While of Logic.expr * Logic.arith_expr option * bool expr * cmd
     (* invariant, optional variant (decreasing measure), guard, body *)
@@ -144,14 +144,20 @@ let expr_to_cmd e = IntExpr (t_int_expr e)
 let t_rhs ~is_bool x e =
   if is_bool x then BoolE (t_bool_expr ~is_bool e) else IntE (t_int_expr e)
 
-let rec t_cmd ~is_bool c =
-  let recur = t_cmd ~is_bool in
+let rec t_cmd ~is_bool ~proc_bool_params c =
+  let recur = t_cmd ~is_bool ~proc_bool_params in
   match c with
   | ULoc (loc, e) -> Located (loc, recur e)
   | USeq (c, c') -> Seq (recur c, recur c')
   | UAssgn (s, e) -> Assgn (s, t_rhs ~is_bool s e)
   | ULet (s, e) -> Let (s, t_rhs ~is_bool s e)
-  | UProc (f, ps) -> Proc (f, List.map ps ~f:t_int_expr)
+  | UProc (f, ps) ->
+      (* Each actual is elaborated at its formal's type: a boolean parameter
+         takes a boolean argument. [Typecheck] has matched the arity. *)
+      let arg is_b e =
+        if is_b then BoolE (t_bool_expr ~is_bool e) else IntE (t_int_expr e)
+      in
+      Proc (f, List.map2_exn (proc_bool_params f) ps ~f:arg)
   | UIf (e, c, c') -> If (t_bool_expr ~is_bool e, recur c, recur c')
   | UWhile (inv, variant, e, c) ->
       While (inv, variant, t_bool_expr ~is_bool e, recur c)
@@ -160,4 +166,4 @@ let rec t_cmd ~is_bool c =
   | UArrAssgn (a, i, e) -> ArrAssgn (a, t_int_expr i, t_int_expr e)
   | v -> expr_to_cmd v
 
-let translate_cmd ~is_bool = t_cmd ~is_bool
+let translate_cmd ~is_bool ~proc_bool_params = t_cmd ~is_bool ~proc_bool_params

--- a/src/ast/program.ml
+++ b/src/ast/program.ml
@@ -16,6 +16,8 @@ type _ expr =
   | Leq : int expr * int expr -> bool expr
   | Gt : int expr * int expr -> bool expr
   | Geq : int expr * int expr -> bool expr
+  | Beq : bool expr * bool expr -> bool expr (* boolean equality [b = c] *)
+  | Bneq : bool expr * bool expr -> bool expr (* boolean inequality [b != c] *)
   | And : bool expr * bool expr -> bool expr
   | Or : bool expr * bool expr -> bool expr
   | Not : bool expr -> bool expr
@@ -85,6 +87,18 @@ type ut_expr =
 
 exception TypeError of string
 
+(* Whether an expression is boolean-typed, used to send [=]/[!=] to the boolean
+   or the integer comparison. A bare variable is boolean iff [is_bool] says so;
+   the syntactic boolean forms are boolean regardless. [Typecheck] has validated
+   that both operands agree, so testing the left one suffices. *)
+let rec is_bool_operand ~is_bool = function
+  | UBool _ | UEq _ | UNeq _ | ULt _ | ULeq _ | UGt _ | UGeq _ | UAnd _ | UOr _
+  | UNot _ ->
+      true
+  | UVar x -> is_bool x
+  | ULoc (_, e) -> is_bool_operand ~is_bool e
+  | _ -> false
+
 let rec t_int_expr = function
   | UInt v -> Value (Int v)
   | UVar v -> Value (VarInst v)
@@ -97,20 +111,26 @@ let rec t_int_expr = function
   | ULen a -> Len a
   | e -> raise (TypeError (show_ut_expr e))
 
-and t_bool_expr = function
+and t_bool_expr ~is_bool e =
+  let recur = t_bool_expr ~is_bool in
+  match e with
   | UBool v -> Value (Bool v)
   (* A bare variable in boolean position is a boolean variable; [Typecheck] has
      already established that [v] is boolean-typed. *)
   | UVar v -> Value (BoolVar v)
-  | UEq (a, b) -> Eq (t_int_expr a, t_int_expr b)
-  | UNeq (a, b) -> Neq (t_int_expr a, t_int_expr b)
+  | UEq (a, b) ->
+      if is_bool_operand ~is_bool a then Beq (recur a, recur b)
+      else Eq (t_int_expr a, t_int_expr b)
+  | UNeq (a, b) ->
+      if is_bool_operand ~is_bool a then Bneq (recur a, recur b)
+      else Neq (t_int_expr a, t_int_expr b)
   | ULt (a, b) -> Lt (t_int_expr a, t_int_expr b)
   | ULeq (a, b) -> Leq (t_int_expr a, t_int_expr b)
   | UGt (a, b) -> Gt (t_int_expr a, t_int_expr b)
   | UGeq (a, b) -> Geq (t_int_expr a, t_int_expr b)
-  | UAnd (a, b) -> And (t_bool_expr a, t_bool_expr b)
-  | UOr (a, b) -> Or (t_bool_expr a, t_bool_expr b)
-  | UNot a -> Not (t_bool_expr a)
+  | UAnd (a, b) -> And (recur a, recur b)
+  | UOr (a, b) -> Or (recur a, recur b)
+  | UNot a -> Not (recur a)
   | e -> raise (TypeError (show_ut_expr e))
 
 (* A bare expression used as a statement: its value is discarded. Any integer
@@ -122,7 +142,7 @@ let expr_to_cmd e = IntExpr (t_int_expr e)
    variable ([is_bool x]) takes a boolean expression, any other an integer one.
    [Typecheck] guarantees the source expression matches. *)
 let t_rhs ~is_bool x e =
-  if is_bool x then BoolE (t_bool_expr e) else IntE (t_int_expr e)
+  if is_bool x then BoolE (t_bool_expr ~is_bool e) else IntE (t_int_expr e)
 
 let rec t_cmd ~is_bool c =
   let recur = t_cmd ~is_bool in
@@ -132,8 +152,9 @@ let rec t_cmd ~is_bool c =
   | UAssgn (s, e) -> Assgn (s, t_rhs ~is_bool s e)
   | ULet (s, e) -> Let (s, t_rhs ~is_bool s e)
   | UProc (f, ps) -> Proc (f, List.map ps ~f:t_int_expr)
-  | UIf (e, c, c') -> If (t_bool_expr e, recur c, recur c')
-  | UWhile (inv, variant, e, c) -> While (inv, variant, t_bool_expr e, recur c)
+  | UIf (e, c, c') -> If (t_bool_expr ~is_bool e, recur c, recur c')
+  | UWhile (inv, variant, e, c) ->
+      While (inv, variant, t_bool_expr ~is_bool e, recur c)
   | UPrint e -> Print (t_int_expr e)
   | UArrMake (a, n) -> ArrMake (a, t_int_expr n)
   | UArrAssgn (a, i, e) -> ArrAssgn (a, t_int_expr i, t_int_expr e)

--- a/src/ast/program.ml
+++ b/src/ast/program.ml
@@ -5,6 +5,7 @@ type _ value =
   | Int : int -> int value
   | Bool : bool -> bool value
   | VarInst : string -> int value
+  | BoolVar : string -> bool value
 [@@deriving sexp_of]
 
 type _ expr =
@@ -27,11 +28,17 @@ type _ expr =
   | Len : string -> int expr (* array length len(a) *)
 [@@deriving sexp_of]
 
+(* An expression of statically-unknown type: the right-hand side of an
+   assignment, which may be an integer or a boolean now that variables can be
+   either. The tag recovers the type the GADT erased so consumers (interpreter,
+   compiler, WLP) can dispatch on it. *)
+type anyexpr = IntE of int expr | BoolE of bool expr [@@deriving sexp_of]
+
 type cmd =
   | IntExpr of int expr
   | Seq of cmd * cmd
-  | Assgn of string * int expr
-  | Let of string * int expr
+  | Assgn of string * anyexpr
+  | Let of string * anyexpr
   | Proc of string * int expr list
   | If of bool expr * cmd * cmd
   | While of Logic.expr * Logic.arith_expr option * bool expr * cmd
@@ -92,6 +99,9 @@ let rec t_int_expr = function
 
 and t_bool_expr = function
   | UBool v -> Value (Bool v)
+  (* A bare variable in boolean position is a boolean variable; [Typecheck] has
+     already established that [v] is boolean-typed. *)
+  | UVar v -> Value (BoolVar v)
   | UEq (a, b) -> Eq (t_int_expr a, t_int_expr b)
   | UNeq (a, b) -> Neq (t_int_expr a, t_int_expr b)
   | ULt (a, b) -> Lt (t_int_expr a, t_int_expr b)
@@ -106,19 +116,27 @@ and t_bool_expr = function
 (* A bare expression used as a statement: its value is discarded. Any integer
    expression is valid here ([t_int_expr] raises [TypeError] on a boolean or a
    nested command); [Typecheck] has already ruled those out by this point. *)
-and expr_to_cmd e = IntExpr (t_int_expr e)
+let expr_to_cmd e = IntExpr (t_int_expr e)
 
-and t_cmd = function
-  | ULoc (loc, e) -> Located (loc, t_cmd e)
-  | USeq (c, c') -> Seq (t_cmd c, t_cmd c')
-  | UAssgn (s, e) -> Assgn (s, t_int_expr e)
-  | ULet (s, e) -> Let (s, t_int_expr e)
+(* Elaborate an assignment right-hand side at its target's type: a boolean-typed
+   variable ([is_bool x]) takes a boolean expression, any other an integer one.
+   [Typecheck] guarantees the source expression matches. *)
+let t_rhs ~is_bool x e =
+  if is_bool x then BoolE (t_bool_expr e) else IntE (t_int_expr e)
+
+let rec t_cmd ~is_bool c =
+  let recur = t_cmd ~is_bool in
+  match c with
+  | ULoc (loc, e) -> Located (loc, recur e)
+  | USeq (c, c') -> Seq (recur c, recur c')
+  | UAssgn (s, e) -> Assgn (s, t_rhs ~is_bool s e)
+  | ULet (s, e) -> Let (s, t_rhs ~is_bool s e)
   | UProc (f, ps) -> Proc (f, List.map ps ~f:t_int_expr)
-  | UIf (e, c, c') -> If (t_bool_expr e, t_cmd c, t_cmd c')
-  | UWhile (inv, variant, e, c) -> While (inv, variant, t_bool_expr e, t_cmd c)
+  | UIf (e, c, c') -> If (t_bool_expr e, recur c, recur c')
+  | UWhile (inv, variant, e, c) -> While (inv, variant, t_bool_expr e, recur c)
   | UPrint e -> Print (t_int_expr e)
   | UArrMake (a, n) -> ArrMake (a, t_int_expr n)
   | UArrAssgn (a, i, e) -> ArrAssgn (a, t_int_expr i, t_int_expr e)
   | v -> expr_to_cmd v
 
-let translate_cmd = t_cmd
+let translate_cmd ~is_bool = t_cmd ~is_bool

--- a/src/ast/program.mli
+++ b/src/ast/program.mli
@@ -29,6 +29,8 @@ type _ expr =
   | Leq : int expr * int expr -> bool expr
   | Gt : int expr * int expr -> bool expr
   | Geq : int expr * int expr -> bool expr
+  | Beq : bool expr * bool expr -> bool expr
+  | Bneq : bool expr * bool expr -> bool expr
   | And : bool expr * bool expr -> bool expr
   | Or : bool expr * bool expr -> bool expr
   | Not : bool expr -> bool expr

--- a/src/ast/program.mli
+++ b/src/ast/program.mli
@@ -6,14 +6,16 @@
     Program {e assertions} live separately in {!Logic}; this module is the code
     that runs. *)
 
-(** Leaf values, GADT-indexed by their OCaml type. [VarInst] is a variable
-    occurrence (always integer-valued, hence [int value]); it names a binding
-    resolved later against the {!Vars} environment. *)
+(** Leaf values, GADT-indexed by their OCaml type. [VarInst] and [BoolVar] are
+    variable occurrences -- integer- and boolean-valued respectively; which one
+    a name elaborates to is fixed by {!Typecheck} and threaded into
+    {!translate_cmd}. Both name a binding resolved later against {!Vars}. *)
 type _ value =
   | Unit : unit -> unit value
   | Int : int -> int value
   | Bool : bool -> bool value
   | VarInst : string -> int value
+  | BoolVar : string -> bool value
 [@@deriving sexp_of]
 
 (** Pure expressions, indexed by result type so the type system rules out
@@ -39,6 +41,10 @@ type _ expr =
   | Len : string -> int expr
 [@@deriving sexp_of]
 
+(** An assignment right-hand side, whose type ([int] or [bool]) is recovered by
+    the tag the GADT erased. *)
+type anyexpr = IntE of int expr | BoolE of bool expr [@@deriving sexp_of]
+
 (** Commands (statements). [Let] introduces a local binding, [Assgn] mutates an
     existing variable, [Proc] is a call by name. [While] carries its loop
     invariant and optional variant (decreasing measure) alongside guard and
@@ -46,8 +52,8 @@ type _ expr =
 type cmd =
   | IntExpr of int expr
   | Seq of cmd * cmd
-  | Assgn of string * int expr
-  | Let of string * int expr
+  | Assgn of string * anyexpr
+  | Let of string * anyexpr
   | Proc of string * int expr list
   | If of bool expr * cmd * cmd
   | While of Logic.expr * Logic.arith_expr option * bool expr * cmd
@@ -98,8 +104,11 @@ exception TypeError of string
     e.g. a boolean where an integer is required, or an expression used where a
     command is expected. Carries the offending node, rendered by [show]. *)
 
-val translate_cmd : ut_expr -> cmd
-(** Type-check and translate the untyped parser output into the typed {!cmd}
-    AST.
+val translate_cmd : is_bool:(string -> bool) -> ut_expr -> cmd
+(** Translate the untyped parser output into the typed {!cmd} AST. [is_bool]
+    reports whether a name is a boolean variable, so its occurrences and the
+    right-hand sides assigned to it elaborate at [bool] rather than [int]; it is
+    supplied by {!Typecheck}, which has already validated well-typedness.
 
-    @raise TypeError on malformed input. *)
+    @raise TypeError on malformed input (a checked program never triggers this).
+*)

--- a/src/ast/program.mli
+++ b/src/ast/program.mli
@@ -56,7 +56,7 @@ type cmd =
   | Seq of cmd * cmd
   | Assgn of string * anyexpr
   | Let of string * anyexpr
-  | Proc of string * int expr list
+  | Proc of string * anyexpr list
   | If of bool expr * cmd * cmd
   | While of Logic.expr * Logic.arith_expr option * bool expr * cmd
   | Print of int expr
@@ -106,11 +106,17 @@ exception TypeError of string
     e.g. a boolean where an integer is required, or an expression used where a
     command is expected. Carries the offending node, rendered by [show]. *)
 
-val translate_cmd : is_bool:(string -> bool) -> ut_expr -> cmd
+val translate_cmd :
+  is_bool:(string -> bool) ->
+  proc_bool_params:(string -> bool list) ->
+  ut_expr ->
+  cmd
 (** Translate the untyped parser output into the typed {!cmd} AST. [is_bool]
     reports whether a name is a boolean variable, so its occurrences and the
-    right-hand sides assigned to it elaborate at [bool] rather than [int]; it is
-    supplied by {!Typecheck}, which has already validated well-typedness.
+    right-hand sides assigned to it elaborate at [bool] rather than [int];
+    [proc_bool_params f] gives, per formal of procedure [f], whether it is
+    boolean, so a call's actuals elaborate at their formals' types. Both come
+    from {!Typecheck}, which has already validated well-typedness.
 
     @raise TypeError on malformed input (a checked program never triggers this).
 *)

--- a/src/ast/runtime.ml
+++ b/src/ast/runtime.ml
@@ -156,6 +156,12 @@ let rec exec_expr : type a. Runtime.t -> a expr -> a =
   | And (a, b) -> exec_expr r a && exec_expr r b
   | Or (a, b) -> exec_expr r a || exec_expr r b
   | Not a -> not (exec_expr r a)
+  | Beq (a, b) ->
+      let v1 = exec_expr r a in
+      v1 = exec_expr r b
+  | Bneq (a, b) ->
+      let v1 = exec_expr r a in
+      v1 <> exec_expr r b
 
 and exec_cmd ?(fuel = ref max_int) r c : int * Runtime.t =
   let exec_cmd r c = exec_cmd ~fuel r c in

--- a/src/ast/runtime.ml
+++ b/src/ast/runtime.ml
@@ -101,6 +101,9 @@ let exec_value r (type a) (v : a value) : a =
   | Int i -> i
   | Bool b -> b
   | VarInst x -> Runtime.find_var r x
+  (* Boolean variables share the integer store, encoded 0/1 (see the [Assgn]
+     case); a read decodes back to a boolean. *)
+  | BoolVar x -> Runtime.find_var r x <> 0
 
 let rec exec_expr : type a. Runtime.t -> a expr -> a =
  fun r v ->
@@ -161,14 +164,20 @@ and exec_cmd ?(fuel = ref max_int) r c : int * Runtime.t =
   | Seq (c, c') ->
       let _, r' = exec_cmd r c in
       exec_cmd r' c'
-  | Assgn (x, e) ->
+  (* A boolean right-hand side is stored 0/1 in the same integer store; the
+     statement's own (discarded) value is 0. *)
+  | Assgn (x, IntE e) ->
       let v = exec_expr r e in
-      let r' = Runtime.add_global_var r x v in
-      (v, r')
-  | Let (x, e) ->
+      (v, Runtime.add_global_var r x v)
+  | Assgn (x, BoolE e) ->
+      let v = if exec_expr r e then 1 else 0 in
+      (0, Runtime.add_global_var r x v)
+  | Let (x, IntE e) ->
       let v = exec_expr r e in
-      let r' = Runtime.add_local_var r x v in
-      (v, r')
+      (v, Runtime.add_local_var r x v)
+  | Let (x, BoolE e) ->
+      let v = if exec_expr r e then 1 else 0 in
+      (0, Runtime.add_local_var r x v)
   | Proc (f, ps) ->
       let ps = List.map (exec_expr r) ps in
       let v, r_proc =

--- a/src/ast/runtime.ml
+++ b/src/ast/runtime.ml
@@ -185,7 +185,12 @@ and exec_cmd ?(fuel = ref max_int) r c : int * Runtime.t =
       let v = if exec_expr r e then 1 else 0 in
       (0, Runtime.add_local_var r x v)
   | Proc (f, ps) ->
-      let ps = List.map (exec_expr r) ps in
+      (* Boolean arguments are passed 0/1, like boolean variables. *)
+      let eval = function
+        | IntE e -> exec_expr r e
+        | BoolE e -> if exec_expr r e then 1 else 0
+      in
+      let ps = List.map eval ps in
       let v, r_proc =
         match Runtime.find_proc r f with
         | { ps = fps; c; _ } ->

--- a/src/ast/triple.ml
+++ b/src/ast/triple.ml
@@ -27,13 +27,13 @@ type t = {
    the typed AST and everything downstream ([Hoare], [Runtime], [Compile]) work
    with plain parameter names. [is_bool] (also from {!Typecheck}) directs the
    elaboration of boolean variables. *)
-let translate ~is_bool { p; f; variant; ws; ps; u; q } =
+let translate ~is_bool ~proc_bool_params { p; f; variant; ws; ps; u; q } =
   {
     p;
     f;
     variant;
     ws;
     ps = List.map fst ps;
-    c = Program.translate_cmd ~is_bool u;
+    c = Program.translate_cmd ~is_bool ~proc_bool_params u;
     q;
   }

--- a/src/ast/triple.ml
+++ b/src/ast/triple.ml
@@ -25,6 +25,15 @@ type t = {
 
 (* Parameter type annotations are validated by {!Typecheck} and dropped here:
    the typed AST and everything downstream ([Hoare], [Runtime], [Compile]) work
-   with plain parameter names. *)
-let translate { p; f; variant; ws; ps; u; q } =
-  { p; f; variant; ws; ps = List.map fst ps; c = Program.translate_cmd u; q }
+   with plain parameter names. [is_bool] (also from {!Typecheck}) directs the
+   elaboration of boolean variables. *)
+let translate ~is_bool { p; f; variant; ws; ps; u; q } =
+  {
+    p;
+    f;
+    variant;
+    ws;
+    ps = List.map fst ps;
+    c = Program.translate_cmd ~is_bool u;
+    q;
+  }

--- a/src/ast/typecheck.ml
+++ b/src/ast/typecheck.ml
@@ -179,7 +179,7 @@ let program_bools (program : Triple.ut_t list) =
 
 (* ===== Expression typing ===== *)
 
-type env = { arrays : SS.t; bools : SS.t; procs : (string * int) list }
+type env = { arrays : SS.t; bools : SS.t; procs : (string * Ty.t list) list }
 
 let require_array env loc a =
   if not (SS.mem a env.arrays) then
@@ -241,12 +241,13 @@ and expect env loc (expected : Ty.t) (e : Program.ut_expr) =
 let check_call env loc f args =
   match List.assoc_opt f env.procs with
   | None -> fail loc "call to undeclared procedure '%s'" f
-  | Some arity ->
+  | Some tys ->
+      let arity = List.length tys in
       let n = List.length args in
       if n <> arity then
         fail loc "procedure '%s' expects %d argument(s) but got %d" f arity n;
-      (* Parameters are integer scalars, so every actual must be an [int]. *)
-      List.iter (expect env loc Ty.Int) args
+      (* Each actual must match its formal's type. *)
+      List.iter2 (fun ty arg -> expect env loc ty arg) tys args
 
 let rec check_cmd env loc (e : Program.ut_expr) : unit =
   let open Program in
@@ -291,54 +292,70 @@ let rec check_cmd env loc (e : Program.ut_expr) : unit =
   | UOr _ | UNot _ ->
       expect env loc Ty.Int e
 
-(* Validate optional parameter annotations. Parameters are integer scalars
-   today, so an [int] annotation is accepted (and redundant) while [bool] or an
-   array type is rejected as not-yet-supported rather than silently ignored. *)
-let check_params (ps : (string * Ty.t option) list) =
+(* Validate optional parameter annotations against the inferred classification.
+   Integer and boolean parameters are supported; arrays (always globals) are
+   not. An [int] annotation must not contradict a boolean use. *)
+let check_params ~arrays ~bools (ps : (string * Ty.t option) list) =
   List.iter
-    (function
-      | _, None | _, Some Ty.Int -> ()
-      | name, Some t ->
-          fail None
-            "parameter '%s' has type %s, but only integer parameters are \
-             supported"
-            name (Ty.to_string t))
+    (fun (name, ann) ->
+      if SS.mem name arrays then
+        fail None "array parameter '%s' is not supported" name;
+      match ann with
+      | None | Some Ty.Bool -> ()
+      | Some Ty.Int ->
+          if SS.mem name bools then
+            fail None "parameter '%s' is annotated int but used as a boolean"
+              name
+      | Some (Ty.Array _) ->
+          fail None "array parameter '%s' is not supported" name)
     ps
 
-let check (program : Triple.ut_t list) : string list =
+type checked = {
+  bool_vars : string list;  (** names of the program's boolean variables *)
+  proc_bool_params : (string * bool list) list;
+      (** per procedure, whether each formal parameter is boolean *)
+}
+
+let check (program : Triple.ut_t list) : checked =
   let arrays = program_arrays program in
-  let bools = program_bools program in
+  (* Boolean names: inferred from bodies and assertions, plus any parameter
+     annotated [: bool]. *)
+  let annotated_bools =
+    List.fold_left
+      (fun s (t : Triple.ut_t) ->
+        List.fold_left
+          (fun s (p, ann) ->
+            match ann with Some Ty.Bool -> SS.add p s | _ -> s)
+          s t.ps)
+      SS.empty program
+  in
+  let bools = SS.union (program_bools program) annotated_bools in
   (* A name cannot be both an array and a boolean. *)
   (match SS.choose_opt (SS.inter arrays bools) with
   | Some x -> fail None "variable '%s' is used as both an array and a boolean" x
   | None -> ());
-  (* Boolean procedure parameters are not yet supported; reject an inferred one
-     (an annotated one is caught by [check_params]). *)
-  let params =
-    List.fold_left
-      (fun s (t : Triple.ut_t) ->
-        List.fold_left (fun s (p, _) -> SS.add p s) s t.ps)
-      SS.empty program
-  in
-  (match SS.choose_opt (SS.inter params bools) with
-  | Some x ->
-      fail None
-        "parameter '%s' is boolean, but only integer parameters are supported" x
-  | None -> ());
+  (* A parameter's type: boolean if inferred or annotated so, else integer.
+     (Array parameters are rejected by [check_params].) *)
+  let param_ty n = if SS.mem n bools then Ty.Bool else Ty.Int in
   (* Every triple but the last is a named procedure; the last is [main] and is
-     not callable. Signatures are (name, arity). *)
+     not callable. A signature is the procedure's parameter types. *)
   let procs =
     match List.rev program with
     | _main :: rev_procs ->
         List.rev_map
-          (fun (t : Triple.ut_t) -> (t.f, List.length t.ps))
+          (fun (t : Triple.ut_t) ->
+            (t.f, List.map (fun (n, _) -> param_ty n) t.ps))
           rev_procs
     | [] -> []
   in
   let env = { arrays; bools; procs } in
   List.iter
     (fun (t : Triple.ut_t) ->
-      check_params t.ps;
+      check_params ~arrays ~bools t.ps;
       check_cmd env None t.u)
     program;
-  SS.elements bools
+  {
+    bool_vars = SS.elements bools;
+    proc_bool_params =
+      List.map (fun (f, tys) -> (f, List.map (Ty.equal Ty.Bool) tys)) procs;
+  }

--- a/src/ast/typecheck.ml
+++ b/src/ast/typecheck.ml
@@ -103,13 +103,77 @@ let program_arrays (program : Triple.ut_t list) =
               (SS.union (arrays_logic t.q) (arrays_measure t.variant)))))
     SS.empty program
 
+(* ===== Boolean-variable inference =====
+   A variable is boolean when a boolean context forces it, with no annotation
+   required: it is assigned a syntactically-boolean expression (a comparison, a
+   connective, or a literal), or it appears as a bare variable in a boolean
+   position -- a loop/if guard, or an operand of &&/||/!. A bare variable merely
+   copied from another (`y := b`) is *not* inferred boolean; that ambiguous case
+   is left to a future annotation. Consistency -- that such a name is not also
+   used as an integer or array -- is checked afterwards by the main pass. *)
+
+let is_syntactically_bool (e : Program.ut_expr) =
+  match e with
+  | UBool _ | UEq _ | UNeq _ | ULt _ | ULeq _ | UGt _ | UGeq _ | UAnd _ | UOr _
+  | UNot _ ->
+      true
+  | _ -> false
+
+let rec classify_bool (e : Program.ut_expr) =
+  let open Program in
+  let ( ++ ) = SS.union in
+  (* A bare variable occupying a position that demands a boolean. *)
+  let bvar = function UVar x -> SS.singleton x | _ -> SS.empty in
+  match e with
+  | UAssgn (x, rhs) | ULet (x, rhs) ->
+      let here =
+        if is_syntactically_bool rhs then SS.singleton x else SS.empty
+      in
+      here ++ classify_bool rhs
+  | UAnd (a, b) | UOr (a, b) ->
+      bvar a ++ bvar b ++ classify_bool a ++ classify_bool b
+  | UNot a -> bvar a ++ classify_bool a
+  | UIf (c, a, b) ->
+      bvar c ++ classify_bool c ++ classify_bool a ++ classify_bool b
+  | UWhile (_inv, _variant, c, body) ->
+      bvar c ++ classify_bool c ++ classify_bool body
+  | USeq (a, b) -> classify_bool a ++ classify_bool b
+  | ULoc (_, e) | UPrint e -> classify_bool e
+  | UArrMake (_, n) -> classify_bool n
+  | UArrAssgn (_, i, e) -> classify_bool i ++ classify_bool e
+  | UProc (_, args) ->
+      List.fold_left (fun s a -> s ++ classify_bool a) SS.empty args
+  | UEq (a, b)
+  | UNeq (a, b)
+  | ULt (a, b)
+  | ULeq (a, b)
+  | UGt (a, b)
+  | UGeq (a, b)
+  | UPlus (a, b)
+  | USub (a, b)
+  | UMul (a, b)
+  | UDiv (a, b)
+  | UMod (a, b) ->
+      classify_bool a ++ classify_bool b
+  | UGet (_, i) -> classify_bool i
+  | UInt _ | UBool _ | UVar _ | ULen _ -> SS.empty
+
+let program_bools (program : Triple.ut_t list) =
+  List.fold_left
+    (fun s (t : Triple.ut_t) -> SS.union s (classify_bool t.u))
+    SS.empty program
+
 (* ===== Expression typing ===== *)
 
-type env = { arrays : SS.t; procs : (string * int) list }
+type env = { arrays : SS.t; bools : SS.t; procs : (string * int) list }
 
 let require_array env loc a =
   if not (SS.mem a env.arrays) then
     fail loc "'%s' is used as an array but is not one" a
+
+(* The type a bare scalar variable has: boolean if inferred so, otherwise
+   integer. (Array names never reach here -- they are rejected as scalars.) *)
+let scalar_type env x = if SS.mem x env.bools then Ty.Bool else Ty.Int
 
 let rec synth env loc (e : Program.ut_expr) : Ty.t =
   let open Program in
@@ -118,8 +182,8 @@ let rec synth env loc (e : Program.ut_expr) : Ty.t =
   | UBool _ -> Ty.Bool
   | UVar x ->
       if SS.mem x env.arrays then
-        fail loc "array '%s' cannot be used as an integer value" x
-      else Ty.Int
+        fail loc "array '%s' cannot be used as a scalar value" x
+      else scalar_type env x
   | UGet (a, i) ->
       require_array env loc a;
       expect env loc Ty.Int i;
@@ -183,7 +247,9 @@ let rec check_cmd env loc (e : Program.ut_expr) : unit =
           "array '%s' cannot be assigned as a scalar (use '%s[i] := ...' or \
            '%s := array(n)')"
           x x x;
-      expect env loc Ty.Int e
+      (* A boolean variable takes a boolean right-hand side, an integer one an
+         integer -- assigning across types is a type error. *)
+      expect env loc (scalar_type env x) e
   | UProc (f, args) -> check_call env loc f args
   | UIf (c, a, b) ->
       expect env loc Ty.Bool c;
@@ -225,8 +291,26 @@ let check_params (ps : (string * Ty.t option) list) =
             name (Ty.to_string t))
     ps
 
-let check (program : Triple.ut_t list) : unit =
+let check (program : Triple.ut_t list) : string list =
   let arrays = program_arrays program in
+  let bools = program_bools program in
+  (* A name cannot be both an array and a boolean. *)
+  (match SS.choose_opt (SS.inter arrays bools) with
+  | Some x -> fail None "variable '%s' is used as both an array and a boolean" x
+  | None -> ());
+  (* Boolean procedure parameters are not yet supported; reject an inferred one
+     (an annotated one is caught by [check_params]). *)
+  let params =
+    List.fold_left
+      (fun s (t : Triple.ut_t) ->
+        List.fold_left (fun s (p, _) -> SS.add p s) s t.ps)
+      SS.empty program
+  in
+  (match SS.choose_opt (SS.inter params bools) with
+  | Some x ->
+      fail None
+        "parameter '%s' is boolean, but only integer parameters are supported" x
+  | None -> ());
   (* Every triple but the last is a named procedure; the last is [main] and is
      not callable. Signatures are (name, arity). *)
   let procs =
@@ -237,9 +321,10 @@ let check (program : Triple.ut_t list) : unit =
           rev_procs
     | [] -> []
   in
-  let env = { arrays; procs } in
+  let env = { arrays; bools; procs } in
   List.iter
     (fun (t : Triple.ut_t) ->
       check_params t.ps;
       check_cmd env None t.u)
-    program
+    program;
+  SS.elements bools

--- a/src/ast/typecheck.ml
+++ b/src/ast/typecheck.ml
@@ -47,7 +47,7 @@ let rec arrays_arith (e : Logic.arith_expr) =
 
 let rec arrays_logic (e : Logic.logic_expr) =
   match e with
-  | Logic.Bool _ -> SS.empty
+  | Logic.Bool _ | Logic.BoolVar _ -> SS.empty
   | Logic.Not e | Logic.Forall (_, e) | Logic.Exists (_, e) -> arrays_logic e
   | Logic.And (a, b) | Logic.Or (a, b) | Logic.Impl (a, b) ->
       SS.union (arrays_logic a) (arrays_logic b)
@@ -158,9 +158,23 @@ let rec classify_bool (e : Program.ut_expr) =
   | UGet (_, i) -> classify_bool i
   | UInt _ | UBool _ | UVar _ | ULen _ -> SS.empty
 
+(* Boolean names mentioned as bare propositions in an assertion. *)
+let rec bools_logic (e : Logic.logic_expr) =
+  match e with
+  | Logic.BoolVar x -> SS.singleton x
+  | Logic.Bool _ | Logic.Eq _ | Logic.Neq _ | Logic.Lt _ | Logic.Leq _
+  | Logic.Gt _ | Logic.Geq _ ->
+      SS.empty
+  | Logic.Not e | Logic.Forall (_, e) | Logic.Exists (_, e) -> bools_logic e
+  | Logic.And (a, b) | Logic.Or (a, b) | Logic.Impl (a, b) ->
+      SS.union (bools_logic a) (bools_logic b)
+
 let program_bools (program : Triple.ut_t list) =
   List.fold_left
-    (fun s (t : Triple.ut_t) -> SS.union s (classify_bool t.u))
+    (fun s (t : Triple.ut_t) ->
+      SS.union s
+        (SS.union (classify_bool t.u)
+           (SS.union (bools_logic t.p) (bools_logic t.q))))
     SS.empty program
 
 (* ===== Expression typing ===== *)

--- a/src/ast/typecheck.ml
+++ b/src/ast/typecheck.ml
@@ -195,14 +195,14 @@ let rec synth env loc (e : Program.ut_expr) : Ty.t =
       expect env loc Ty.Int a;
       expect env loc Ty.Int b;
       Ty.Int
-  | UEq (a, b)
-  | UNeq (a, b)
-  | ULt (a, b)
-  | ULeq (a, b)
-  | UGt (a, b)
-  | UGeq (a, b) ->
+  | ULt (a, b) | ULeq (a, b) | UGt (a, b) | UGeq (a, b) ->
       expect env loc Ty.Int a;
       expect env loc Ty.Int b;
+      Ty.Bool
+  (* Equality is homogeneous: both operands must have the same type (integer or
+     boolean), and the result is boolean. *)
+  | UEq (a, b) | UNeq (a, b) ->
+      expect env loc (synth env loc a) b;
       Ty.Bool
   | UAnd (a, b) | UOr (a, b) ->
       expect env loc Ty.Bool a;

--- a/src/ast/typecheck.ml
+++ b/src/ast/typecheck.ml
@@ -169,6 +169,33 @@ let rec bools_logic (e : Logic.logic_expr) =
   | Logic.And (a, b) | Logic.Or (a, b) | Logic.Impl (a, b) ->
       SS.union (bools_logic a) (bools_logic b)
 
+(* Copy edges [(v, x)] from each assignment [x := v] of a bare variable: if [v]
+   is boolean then so is [x]. Saturating these (see [check]) infers the type of
+   a variable copied from a boolean, which [classify_bool] alone leaves
+   ambiguous. *)
+let rec copy_edges (e : Program.ut_expr) : (string * string) list =
+  let open Program in
+  match e with
+  | UAssgn (x, UVar v) | ULet (x, UVar v) -> [ (v, x) ]
+  | UAssgn (_, rhs) | ULet (_, rhs) -> copy_edges rhs
+  | USeq (a, b) -> copy_edges a @ copy_edges b
+  | ULoc (_, e) | UPrint e -> copy_edges e
+  | UIf (_, a, b) -> copy_edges a @ copy_edges b
+  | UWhile (_, _, _, body) -> copy_edges body
+  | _ -> []
+
+let program_copy_edges (program : Triple.ut_t list) =
+  List.concat_map (fun (t : Triple.ut_t) -> copy_edges t.u) program
+
+(* Propagate boolean-ness along copy edges to a fixpoint. *)
+let rec saturate_bools bools edges =
+  let bools' =
+    List.fold_left
+      (fun acc (v, x) -> if SS.mem v acc then SS.add x acc else acc)
+      bools edges
+  in
+  if SS.equal bools' bools then bools else saturate_bools bools' edges
+
 let program_bools (program : Triple.ut_t list) =
   List.fold_left
     (fun s (t : Triple.ut_t) ->
@@ -236,6 +263,70 @@ and expect env loc (expected : Ty.t) (e : Program.ut_expr) =
     fail loc "expected %s but got %s" (Ty.to_string expected)
       (Ty.to_string actual)
 
+(* ===== Assertion typing =====
+   The logic language carries no source locations, so its diagnostics name the
+   offending variable rather than a line. [bound] holds quantifier-bound names,
+   which shadow program variables and are integer-valued (like [Vars.create_fresh]). *)
+
+let rec synth_arith env bound (e : Logic.arith_expr) : Ty.t =
+  match e with
+  | Logic.Int _ -> Ty.Int
+  | Logic.Var x ->
+      if SS.mem x bound then Ty.Int
+      else if SS.mem x env.arrays then
+        fail None "array '%s' cannot be used as a scalar in an assertion" x
+      else if SS.mem x env.bools then Ty.Bool
+      else Ty.Int
+  | Logic.Plus (a, b)
+  | Logic.Sub (a, b)
+  | Logic.Mul (a, b)
+  | Logic.Div (a, b)
+  | Logic.Mod (a, b) ->
+      expect_arith env bound Ty.Int a;
+      expect_arith env bound Ty.Int b;
+      Ty.Int
+  | Logic.Get (a, i) ->
+      require_array env None a;
+      expect_arith env bound Ty.Int i;
+      Ty.Int
+  | Logic.Len a ->
+      require_array env None a;
+      Ty.Int
+
+and expect_arith env bound expected e =
+  let actual = synth_arith env bound e in
+  if not (Ty.equal actual expected) then
+    fail None "expected %s but got %s in an assertion" (Ty.to_string expected)
+      (Ty.to_string actual)
+
+let rec check_logic env bound (e : Logic.logic_expr) : unit =
+  match e with
+  | Logic.Bool _ -> ()
+  | Logic.BoolVar x ->
+      if SS.mem x bound then
+        fail None "quantified variable '%s' is not a boolean proposition" x
+      else if SS.mem x env.arrays then
+        fail None "array '%s' cannot be used as a proposition" x
+      else if not (SS.mem x env.bools) then
+        fail None "'%s' is not a boolean but is used as a proposition" x
+  | Logic.Not e -> check_logic env bound e
+  | Logic.And (a, b) | Logic.Or (a, b) | Logic.Impl (a, b) ->
+      check_logic env bound a;
+      check_logic env bound b
+  (* Equality is homogeneous over integers or booleans; the other comparisons
+     are integer-only. *)
+  | Logic.Eq (a, b) | Logic.Neq (a, b) ->
+      expect_arith env bound (synth_arith env bound a) b
+  | Logic.Lt (a, b) | Logic.Leq (a, b) | Logic.Gt (a, b) | Logic.Geq (a, b) ->
+      expect_arith env bound Ty.Int a;
+      expect_arith env bound Ty.Int b
+  | Logic.Forall (x, e) | Logic.Exists (x, e) ->
+      check_logic env (SS.add x bound) e
+
+let check_measure env = function
+  | Some m -> expect_arith env SS.empty Ty.Int m
+  | None -> ()
+
 (* ===== Command typing ===== *)
 
 let check_call env loc f args =
@@ -270,10 +361,9 @@ let rec check_cmd env loc (e : Program.ut_expr) : unit =
       expect env loc Ty.Bool c;
       check_cmd env loc a;
       check_cmd env loc b
-  | UWhile (_inv, _variant, c, body) ->
-      (* The invariant/variant are logic assertions, typed on the [Logic] side;
-         here we only constrain the loop guard to be boolean and check the
-         body. *)
+  | UWhile (inv, variant, c, body) ->
+      check_logic env SS.empty inv;
+      check_measure env variant;
       expect env loc Ty.Bool c;
       check_cmd env loc body
   | UPrint e -> expect env loc Ty.Int e
@@ -329,7 +419,13 @@ let check (program : Triple.ut_t list) : checked =
           s t.ps)
       SS.empty program
   in
-  let bools = SS.union (program_bools program) annotated_bools in
+  (* Base boolean names, then saturated along copy edges so a variable copied
+     from a boolean (`y := b`) is itself boolean. *)
+  let bools =
+    saturate_bools
+      (SS.union (program_bools program) annotated_bools)
+      (program_copy_edges program)
+  in
   (* A name cannot be both an array and a boolean. *)
   (match SS.choose_opt (SS.inter arrays bools) with
   | Some x -> fail None "variable '%s' is used as both an array and a boolean" x
@@ -352,6 +448,9 @@ let check (program : Triple.ut_t list) : checked =
   List.iter
     (fun (t : Triple.ut_t) ->
       check_params ~arrays ~bools t.ps;
+      check_logic env SS.empty t.p;
+      check_logic env SS.empty t.q;
+      check_measure env t.variant;
       check_cmd env None t.u)
     program;
   {

--- a/src/ast/typecheck.mli
+++ b/src/ast/typecheck.mli
@@ -13,8 +13,15 @@ exception Type_error of Loc.t option * string
 (** The source location of the offending construct (when known) and a
     human-readable message. *)
 
-val check : Triple.ut_t list -> string list
-(** Returns the names of the program's boolean variables (inferred from boolean
-    contexts), which drives how {!Triple.translate} elaborates them.
+type checked = {
+  bool_vars : string list;  (** names of the program's boolean variables *)
+  proc_bool_params : (string * bool list) list;
+      (** per procedure, whether each formal parameter is boolean *)
+}
+
+val check : Triple.ut_t list -> checked
+(** Validate well-typedness and return the information {!Triple.translate} needs
+    to elaborate boolean occurrences: the boolean variable names and, per
+    procedure, which formal parameters are boolean.
 
     @raise Type_error if the program is not well-typed. *)

--- a/src/ast/typecheck.mli
+++ b/src/ast/typecheck.mli
@@ -13,5 +13,8 @@ exception Type_error of Loc.t option * string
 (** The source location of the offending construct (when known) and a
     human-readable message. *)
 
-val check : Triple.ut_t list -> unit
-(** @raise Type_error if the program is not well-typed. *)
+val check : Triple.ut_t list -> string list
+(** Returns the names of the program's boolean variables (inferred from boolean
+    contexts), which drives how {!Triple.translate} elaborates them.
+
+    @raise Type_error if the program is not well-typed. *)

--- a/src/ast/var_collection.ml
+++ b/src/ast/var_collection.ml
@@ -64,7 +64,7 @@ let collect_program c =
     | Gt (e, e')
     | Geq (e, e') ->
         Str_set.union (collect_expr e) (collect_expr e')
-    | And (e, e') | Or (e, e') ->
+    | And (e, e') | Or (e, e') | Beq (e, e') | Bneq (e, e') ->
         Str_set.union (collect_expr e) (collect_expr e')
     | Not e -> collect_expr e
     | Get (a, e) -> Str_set.add a (collect_expr e)
@@ -144,7 +144,8 @@ let arrays_program c =
     | Gt (a, b)
     | Geq (a, b) ->
         Str_set.union (expr a) (expr b)
-    | And (a, b) | Or (a, b) -> Str_set.union (expr a) (expr b)
+    | And (a, b) | Or (a, b) | Beq (a, b) | Bneq (a, b) ->
+        Str_set.union (expr a) (expr b)
     | Not a -> expr a
   in
   let any = function IntE e -> expr e | BoolE e -> expr e in
@@ -192,7 +193,8 @@ let bools_program c =
     | Gt (a, b)
     | Geq (a, b) ->
         Str_set.union (expr a) (expr b)
-    | And (a, b) | Or (a, b) -> Str_set.union (expr a) (expr b)
+    | And (a, b) | Or (a, b) | Beq (a, b) | Bneq (a, b) ->
+        Str_set.union (expr a) (expr b)
     | Not a -> expr a
   in
   let rec cmd = function

--- a/src/ast/var_collection.ml
+++ b/src/ast/var_collection.ml
@@ -29,6 +29,7 @@ let collect_logic e =
   let open Logic in
   let rec collect_logic_expr = function
     | Bool _ -> Str_set.empty
+    | BoolVar x -> Str_set.singleton x
     | Not e -> collect_logic_expr e
     | And (e, e') | Or (e, e') | Impl (e, e') ->
         Str_set.union (collect_logic_expr e) (collect_logic_expr e')
@@ -117,7 +118,7 @@ let arrays_logic e =
   let open Logic in
   let arith = arrays_arith in
   let rec logic = function
-    | Bool _ -> Str_set.empty
+    | Bool _ | BoolVar _ -> Str_set.empty
     | Not e | Forall (_, e) | Exists (_, e) -> logic e
     | And (a, b) | Or (a, b) | Impl (a, b) -> Str_set.union (logic a) (logic b)
     | Eq (a, b) | Neq (a, b) | Lt (a, b) | Leq (a, b) | Gt (a, b) | Geq (a, b)
@@ -230,9 +231,25 @@ let all_arrays (program : Triple.t list) =
               (Str_set.union (arrays_logic t.q) (arrays_program t.c)))))
     Str_set.empty program
 
+(* Boolean names an assertion mentions as bare propositions ([BoolVar]). A
+   boolean equality [b = c] instead parses as an arithmetic [Eq] over [Var]s, so
+   those names are classified boolean by their (body) assignment, not here. *)
+let bools_logic e =
+  let open Logic in
+  let rec go = function
+    | BoolVar x -> Str_set.singleton x
+    | Bool _ | Eq _ | Neq _ | Lt _ | Leq _ | Gt _ | Geq _ -> Str_set.empty
+    | Not e | Forall (_, e) | Exists (_, e) -> go e
+    | And (a, b) | Or (a, b) | Impl (a, b) -> Str_set.union (go a) (go b)
+  in
+  go e
+
 let all_bools (program : Triple.t list) =
   List.fold_left
-    (fun s (t : Triple.t) -> Str_set.union s (bools_program t.c))
+    (fun s (t : Triple.t) ->
+      Str_set.union s
+        (Str_set.union (bools_program t.c)
+           (Str_set.union (bools_logic t.p) (bools_logic t.q))))
     Str_set.empty program
 
 let collect_procedure globals (t : Triple.t) =

--- a/src/ast/var_collection.ml
+++ b/src/ast/var_collection.ml
@@ -47,7 +47,7 @@ let collect_logic e =
 let collect_program c =
   let open Program in
   let collect_value : type a. a value -> Str_set.t = function
-    | VarInst str -> Str_set.singleton str
+    | VarInst str | BoolVar str -> Str_set.singleton str
     | Int _ | Bool _ | Unit () -> Str_set.empty
   in
   let rec collect_expr : type a. a expr -> Str_set.t = function
@@ -70,12 +70,15 @@ let collect_program c =
     | Get (a, e) -> Str_set.add a (collect_expr e)
     | Len a -> Str_set.singleton a
   in
+  let collect_any = function
+    | IntE e -> collect_expr e
+    | BoolE e -> collect_expr e
+  in
   let rec collect_cmd = function
     | Located (_, c) -> collect_cmd c
     | IntExpr e -> collect_expr e
     | Seq (c, c') -> Str_set.union (collect_cmd c) (collect_cmd c')
-    | Assgn (x, e) | Let (x, e) ->
-        Str_set.(union (singleton x) (collect_expr e))
+    | Assgn (x, e) | Let (x, e) -> Str_set.(union (singleton x) (collect_any e))
     | Proc (_f, ps) ->
         List.fold_left
           (fun s e -> collect_expr e |> Str_set.union s)
@@ -144,9 +147,11 @@ let arrays_program c =
     | And (a, b) | Or (a, b) -> Str_set.union (expr a) (expr b)
     | Not a -> expr a
   in
+  let any = function IntE e -> expr e | BoolE e -> expr e in
   let rec cmd = function
     | Located (_, c) -> cmd c
-    | IntExpr e | Print e | Assgn (_, e) | Let (_, e) -> expr e
+    | IntExpr e | Print e -> expr e
+    | Assgn (_, e) | Let (_, e) -> any e
     | Seq (a, b) -> Str_set.union (cmd a) (cmd b)
     | If (b, c, c') -> Str_set.union (expr b) (Str_set.union (cmd c) (cmd c'))
     | While (inv, variant, b, c) ->
@@ -157,6 +162,51 @@ let arrays_program c =
         List.fold_left (fun s e -> Str_set.union s (expr e)) Str_set.empty ps
     | ArrMake (a, n) -> Str_set.add a (expr n)
     | ArrAssgn (a, i, e) -> Str_set.add a (Str_set.union (expr i) (expr e))
+  in
+  cmd c
+
+(* Names used as booleans: a variable read as a [BoolVar], or the target of an
+   assignment whose right-hand side is boolean ([BoolE]). Parallels
+   [arrays_program]; assertions are omitted since the logic language has no
+   boolean program-variable occurrences. A boolean name is given a [bool]-sorted
+   symbol by [str_set_to_vars]. *)
+let bools_program c =
+  let open Program in
+  let value : type a. a value -> Str_set.t = function
+    | BoolVar x -> Str_set.singleton x
+    | VarInst _ | Int _ | Bool _ | Unit () -> Str_set.empty
+  in
+  let rec expr : type a. a expr -> Str_set.t = function
+    | Value v -> value v
+    | Get (_, e) -> expr e
+    | Len _ -> Str_set.empty
+    | Plus (a, b)
+    | Sub (a, b)
+    | Mul (a, b)
+    | Div (a, b)
+    | Mod (a, b)
+    | Eq (a, b)
+    | Neq (a, b)
+    | Lt (a, b)
+    | Leq (a, b)
+    | Gt (a, b)
+    | Geq (a, b) ->
+        Str_set.union (expr a) (expr b)
+    | And (a, b) | Or (a, b) -> Str_set.union (expr a) (expr b)
+    | Not a -> expr a
+  in
+  let rec cmd = function
+    | Located (_, c) -> cmd c
+    | IntExpr e | Print e -> expr e
+    | Assgn (x, BoolE e) | Let (x, BoolE e) -> Str_set.add x (expr e)
+    | Assgn (_, IntE e) | Let (_, IntE e) -> expr e
+    | Seq (a, b) -> Str_set.union (cmd a) (cmd b)
+    | If (b, c, c') -> Str_set.union (expr b) (Str_set.union (cmd c) (cmd c'))
+    | While (_inv, _variant, b, c) -> Str_set.union (expr b) (cmd c)
+    | Proc (_, ps) ->
+        List.fold_left (fun s e -> Str_set.union s (expr e)) Str_set.empty ps
+    | ArrMake (_, n) -> expr n
+    | ArrAssgn (_, i, e) -> Str_set.union (expr i) (expr e)
   in
   cmd c
 
@@ -178,6 +228,11 @@ let all_arrays (program : Triple.t list) =
               (Str_set.union (arrays_logic t.q) (arrays_program t.c)))))
     Str_set.empty program
 
+let all_bools (program : Triple.t list) =
+  List.fold_left
+    (fun s (t : Triple.t) -> Str_set.union s (bools_program t.c))
+    Str_set.empty program
+
 let collect_procedure globals (t : Triple.t) =
   let p_vars = collect_logic t.p in
   let q_vars = collect_logic t.q in
@@ -187,7 +242,7 @@ let collect_procedure globals (t : Triple.t) =
   (* If global variables occur in the procedure, don't add them as local variables *)
   Str_set.fold (fun global vars -> Str_set.remove global vars) globals vars
 
-let str_set_to_vars ~arrays vars =
+let str_set_to_vars ~arrays ~bools vars =
   let f x vs =
     if Str_set.mem x arrays then
       (* An array contributes two symbols: its [map int int] element store and a
@@ -195,6 +250,7 @@ let str_set_to_vars ~arrays vars =
       Vars.add x
         (Vars.create_fresh_array x)
         (Vars.add (Vars.len_key x) (Vars.create_fresh (Vars.len_key x)) vs)
+    else if Str_set.mem x bools then Vars.add x (Vars.create_fresh_bool x) vs
     else Vars.add x (Vars.create_fresh x) vs
   in
   Str_set.fold f vars Vars.empty
@@ -202,14 +258,17 @@ let str_set_to_vars ~arrays vars =
 let collect (program : Triple.t list) =
   let procedures, main = split_last program in
   let arrays = all_arrays program in
+  let bools = all_bools program in
   let globals =
     Str_set.union (collect_procedure Str_set.empty main) (all_writes program)
   in
   let procedures =
     List.map
       (fun proc ->
-        let vars = str_set_to_vars ~arrays (collect_procedure globals proc) in
+        let vars =
+          str_set_to_vars ~arrays ~bools (collect_procedure globals proc)
+        in
         (proc, vars))
       procedures
   in
-  procedures @ [ (main, str_set_to_vars ~arrays globals) ]
+  procedures @ [ (main, str_set_to_vars ~arrays ~bools globals) ]

--- a/src/ast/var_collection.ml
+++ b/src/ast/var_collection.ml
@@ -82,7 +82,7 @@ let collect_program c =
     | Assgn (x, e) | Let (x, e) -> Str_set.(union (singleton x) (collect_any e))
     | Proc (_f, ps) ->
         List.fold_left
-          (fun s e -> collect_expr e |> Str_set.union s)
+          (fun s e -> collect_any e |> Str_set.union s)
           Str_set.empty ps
     | If (b, e, e') ->
         Str_set.union (collect_expr b)
@@ -161,7 +161,7 @@ let arrays_program c =
           (Str_set.union (arrays_logic inv) (arrays_measure variant))
           (Str_set.union (expr b) (cmd c))
     | Proc (_, ps) ->
-        List.fold_left (fun s e -> Str_set.union s (expr e)) Str_set.empty ps
+        List.fold_left (fun s e -> Str_set.union s (any e)) Str_set.empty ps
     | ArrMake (a, n) -> Str_set.add a (expr n)
     | ArrAssgn (a, i, e) -> Str_set.add a (Str_set.union (expr i) (expr e))
   in
@@ -198,6 +198,7 @@ let bools_program c =
         Str_set.union (expr a) (expr b)
     | Not a -> expr a
   in
+  let any = function IntE e -> expr e | BoolE e -> expr e in
   let rec cmd = function
     | Located (_, c) -> cmd c
     | IntExpr e | Print e -> expr e
@@ -207,7 +208,7 @@ let bools_program c =
     | If (b, c, c') -> Str_set.union (expr b) (Str_set.union (cmd c) (cmd c'))
     | While (_inv, _variant, b, c) -> Str_set.union (expr b) (cmd c)
     | Proc (_, ps) ->
-        List.fold_left (fun s e -> Str_set.union s (expr e)) Str_set.empty ps
+        List.fold_left (fun s e -> Str_set.union s (any e)) Str_set.empty ps
     | ArrMake (_, n) -> expr n
     | ArrAssgn (_, i, e) -> Str_set.union (expr i) (expr e)
   in

--- a/src/ast/vars.ml
+++ b/src/ast/vars.ml
@@ -14,6 +14,11 @@ let union (a : t) (b : t) = M.union (fun _ v _ -> Some v) a b
 let fold = M.fold
 let create_fresh x = Why3.(Term.create_vsymbol (Ident.id_fresh x) Ty.ty_int)
 
+(* A boolean-valued variable. Its Why3 sort is [bool], distinct from the [int]
+   of [create_fresh], so terms over it are boolean-sorted. *)
+let create_fresh_bool x =
+  Why3.(Term.create_vsymbol (Ident.id_fresh x) Ty.ty_bool)
+
 (* An array-valued variable ([map int int]); its element store. *)
 let create_fresh_array x =
   Why3.Term.create_vsymbol (Why3.Ident.id_fresh x) (Lazy.force Arith.ty_int_map)

--- a/src/ast/vars.mli
+++ b/src/ast/vars.mli
@@ -39,6 +39,9 @@ val create_fresh : string -> Why3.Term.vsymbol
 (** A fresh integer-valued ([int]) [vsymbol] with a unique name derived from the
     argument. *)
 
+val create_fresh_bool : string -> Why3.Term.vsymbol
+(** A fresh boolean-valued ([bool]) [vsymbol]. *)
+
 val create_fresh_array : string -> Why3.Term.vsymbol
 (** A fresh array-valued ([map int int]) variable. *)
 

--- a/src/compile.ml
+++ b/src/compile.ml
@@ -141,7 +141,8 @@ let rec arrays_expr : type a. a expr -> Str_set.t = function
   | Gt (a, b)
   | Geq (a, b) ->
       Str_set.union (arrays_expr a) (arrays_expr b)
-  | And (a, b) | Or (a, b) -> Str_set.union (arrays_expr a) (arrays_expr b)
+  | And (a, b) | Or (a, b) | Beq (a, b) | Bneq (a, b) ->
+      Str_set.union (arrays_expr a) (arrays_expr b)
   | Not a -> arrays_expr a
 
 let rec arrays = function
@@ -222,6 +223,8 @@ let emit_bool ~ops ~locals (e : bool expr) : string =
     | And (a, b) -> Printf.sprintf "(%s && %s)" (go a) (go b)
     | Or (a, b) -> Printf.sprintf "(%s || %s)" (go a) (go b)
     | Not a -> Printf.sprintf "(not %s)" (go a)
+    | Beq (a, b) -> Printf.sprintf "(%s = %s)" (go a) (go b)
+    | Bneq (a, b) -> Printf.sprintf "(%s <> %s)" (go a) (go b)
   in
   go e
 

--- a/src/compile.ml
+++ b/src/compile.ml
@@ -157,9 +157,8 @@ let rec arrays = function
   | ArrAssgn (a, i, e) ->
       Str_set.add a (Str_set.union (arrays_expr i) (arrays_expr e))
   | Proc (_, ps) ->
-      List.fold_left
-        (fun s e -> Str_set.union s (arrays_expr e))
-        Str_set.empty ps
+      let any = function IntE e -> arrays_expr e | BoolE e -> arrays_expr e in
+      List.fold_left (fun s e -> Str_set.union s (any e)) Str_set.empty ps
 
 (* Boolean scalar globals: assignment targets whose right-hand side is boolean.
    They compile to a [bool ref] rather than the default [int ref] (see [emit]).
@@ -277,13 +276,15 @@ let rec emit_cmd ~ops ~locals c : string =
       Printf.sprintf "(while %s do ignore (%s : %s) done; %s)"
         (emit_bool ~ops ~locals b) (emit_cmd ~ops ~locals c) ops.ty ops.zero
   | Proc (f, args) ->
+      let emit_arg = function
+        | IntE e -> emit_int ~ops ~locals e
+        | BoolE e -> emit_bool ~ops ~locals e
+      in
       let args =
         match args with
         | [] -> " ()"
         | _ ->
-            List.map
-              (fun a -> Printf.sprintf " (%s)" (emit_int ~ops ~locals a))
-              args
+            List.map (fun a -> Printf.sprintf " (%s)" (emit_arg a)) args
             |> String.concat ""
       in
       Printf.sprintf "(%s%s)" (pname f) args

--- a/src/compile.ml
+++ b/src/compile.ml
@@ -149,7 +149,9 @@ let rec arrays = function
   | Seq (c, c') -> Str_set.union (arrays c) (arrays c')
   | If (_, c, c') -> Str_set.union (arrays c) (arrays c')
   | While (_, _, _, c) -> arrays c
-  | Assgn (_, e) | Let (_, e) | Print e | IntExpr e -> arrays_expr e
+  | Print e | IntExpr e -> arrays_expr e
+  | Assgn (_, IntE e) | Let (_, IntE e) -> arrays_expr e
+  | Assgn (_, BoolE e) | Let (_, BoolE e) -> arrays_expr e
   | ArrMake (a, n) -> Str_set.add a (arrays_expr n)
   | ArrAssgn (a, i, e) ->
       Str_set.add a (Str_set.union (arrays_expr i) (arrays_expr e))
@@ -157,6 +159,21 @@ let rec arrays = function
       List.fold_left
         (fun s e -> Str_set.union s (arrays_expr e))
         Str_set.empty ps
+
+(* Boolean scalar globals: assignment targets whose right-hand side is boolean.
+   They compile to a [bool ref] rather than the default [int ref] (see [emit]).
+   A boolean global read but never assigned is, like any uninitialised variable,
+   left undeclared so [ocamlopt] rejects it -- matching the interpreter. *)
+let rec bool_scalars = function
+  | Located (_, c) -> bool_scalars c
+  | Seq (c, c') -> Str_set.union (bool_scalars c) (bool_scalars c')
+  | Assgn (x, BoolE _) | Let (x, BoolE _) -> Str_set.singleton x
+  | If (_, c, c') -> Str_set.union (bool_scalars c) (bool_scalars c')
+  | While (_, _, _, c) -> bool_scalars c
+  | Assgn (_, IntE _)
+  | Let (_, IntE _)
+  | Print _ | IntExpr _ | Proc _ | ArrMake _ | ArrAssgn _ ->
+      Str_set.empty
 
 (* [locals] is the set of program names currently bound in the local store
    (formals + in-scope [let]s). A read resolves local-first then global, the
@@ -195,6 +212,7 @@ let emit_bool ~ops ~locals (e : bool expr) : string =
   let rec go (e : bool expr) : string =
     match e with
     | Value (Bool b) -> string_of_bool b
+    | Value (BoolVar x) -> emit_read ~locals x
     | Eq (a, b) -> cmp ops.eq a b
     | Neq (a, b) -> Printf.sprintf "(not %s)" (cmp ops.eq a b)
     | Lt (a, b) -> cmp ops.lt a b
@@ -224,10 +242,17 @@ let rec emit_cmd ~ops ~locals c : string =
   match c with
   | Located (_, c) -> emit_cmd ~ops ~locals c
   | Seq _ -> emit_block ~ops ~locals (flatten c)
-  | Assgn (x, e) ->
+  | Assgn (x, IntE e) ->
       Printf.sprintf "(%s := %s; %s)" (gref x) (emit_int ~ops ~locals e)
         (emit_read ~locals x)
-  | Let (_, e) -> emit_int ~ops ~locals e (* trailing/standalone: value only *)
+  | Assgn (x, BoolE e) ->
+      (* Store the boolean; the statement's own value is 0 (as in the
+         interpreter), so the epilogue's [int] result stays well-typed. *)
+      Printf.sprintf "(%s := %s; %s)" (gref x) (emit_bool ~ops ~locals e)
+        ops.zero
+  | Let (_, IntE e) ->
+      emit_int ~ops ~locals e (* trailing/standalone: value only *)
+  | Let (_, BoolE _) -> ops.zero
   | Print e ->
       Printf.sprintf "(print_string (%s (%s)); print_newline (); %s)"
         ops.to_string (emit_int ~ops ~locals e) ops.zero
@@ -264,7 +289,12 @@ and emit_block ~ops ~locals : cmd list -> string = function
   | [] -> ops.zero
   | [ s ] -> emit_cmd ~ops ~locals s
   | Let (x, e) :: rest ->
-      Printf.sprintf "(let %s = %s in\n%s)" (lname x) (emit_int ~ops ~locals e)
+      let rhs =
+        match e with
+        | IntE e -> emit_int ~ops ~locals e
+        | BoolE e -> emit_bool ~ops ~locals e
+      in
+      Printf.sprintf "(let %s = %s in\n%s)" (lname x) rhs
         (emit_block ~ops ~locals:(Str_set.add x locals) rest)
   | s :: rest ->
       Printf.sprintf "(ignore (%s : %s);\n%s)" (emit_cmd ~ops ~locals s) ops.ty
@@ -297,10 +327,24 @@ let emit ?(native_int = false) (program : (Triple.t * Vars.t) list) : string =
       (fun acc (t, _) -> Str_set.union acc (assigned t.Triple.c))
       Str_set.empty program
   in
+  let bool_refs =
+    List.fold_left
+      (fun acc (t, _) -> Str_set.union acc (bool_scalars t.Triple.c))
+      Str_set.empty program
+  in
+  (* Boolean scalars are [bool ref]s initialised to [false]; the remaining
+     scalars are integer [ref]s initialised to the backend zero. *)
   let decls =
-    Str_set.elements refs
-    |> List.map (fun x -> Printf.sprintf "let %s = ref %s" (gref x) ops.zero)
-    |> String.concat "\n"
+    let int_refs = Str_set.diff refs bool_refs in
+    let int_decls =
+      Str_set.elements int_refs
+      |> List.map (fun x -> Printf.sprintf "let %s = ref %s" (gref x) ops.zero)
+    in
+    let bool_decls =
+      Str_set.elements bool_refs
+      |> List.map (fun x -> Printf.sprintf "let %s = ref false" (gref x))
+    in
+    String.concat "\n" (int_decls @ bool_decls)
   in
   (* Array globals start as an empty [array ref]; [a := array(n)] replaces it
      with a zero-filled array of the requested length. *)

--- a/src/hoare.ml
+++ b/src/hoare.ml
@@ -100,7 +100,9 @@ let val_to_term : type a. g_vars:Vars.t -> ?l_vars:Vars.t -> a value -> T.term =
   | Unit _ -> unit_term
   | Int v -> T.t_nat_const v
   | Bool b -> if b then T.t_bool_true else T.t_bool_false
-  | VarInst x -> (
+  (* Integer and boolean variables resolve identically -- to their [vsymbol],
+     whose Why3 sort ([int] or [bool]) was fixed by {!Var_collection}. *)
+  | VarInst x | BoolVar x -> (
       match l_vars with
       | Some l_vars -> T.t_var @@ Vars.find_fallback x l_vars g_vars
       | None -> T.t_var @@ Vars.find x g_vars)
@@ -116,6 +118,13 @@ let rec expr_to_term : type a.
   in
   let open Arith in
   match e with
+  (* A boolean expression must translate to a Why3 *formula* (Prop), since it is
+     used as a guard or under the connectives. A boolean literal or variable is a
+     [bool]-sorted term, so coerce it with [= True]; comparisons and connectives
+     already yield formulas. *)
+  | Value (Bool b) -> if b then T.t_true else T.t_false
+  | Value (BoolVar _ as v) ->
+      T.t_equ (val_to_term ~g_vars ?l_vars v) T.t_bool_true
   | Value v -> val_to_term ~g_vars ?l_vars v
   | Eq (e, e') -> eq (f e) (f e')
   | Neq (e, e') -> neq (f e) (f e')
@@ -375,17 +384,30 @@ module Wlp = struct
     | IntExpr e -> T.t_and_simp (safe_e e) q
     | Print e -> T.t_and_simp (safe_e e) q
     | Seq (c, c') -> cmd c (cmd c' q)
-    | Assgn (x, e) | Let (x, e) ->
-        (* safe(e) /\ forall y. y = e -> q[ x <- y ] *)
-        let e_t = expr_to_term ~g_vars ~l_vars e in
+    | Assgn (x, ae) | Let (x, ae) ->
+        (* safe(e) /\ forall y. y = e -> q[ x <- y ]. The right-hand side may be
+           integer or boolean; [e_t] and the fresh [y] take the target's sort
+           ([fresh_like] rather than the integer [create_fresh]), so a boolean
+           assignment substitutes a boolean-sorted term. *)
+        let e_t, safe =
+          match ae with
+          | IntE e -> (expr_to_term ~g_vars ~l_vars e, safe_e e)
+          | BoolE e ->
+              (* The right-hand side is a formula; store it into the
+                 [bool]-sorted variable by coercing it back to a [bool] term. *)
+              ( T.t_if
+                  (expr_to_term ~g_vars ~l_vars e)
+                  T.t_bool_true T.t_bool_false,
+                safe_e e )
+        in
         let x = Vars.find_fallback x l_vars g_vars in
-        let y = Vars.create_fresh "y" in
+        let y = Vars.fresh_like x in
         let y_t = T.t_var y in
         let q_sub = T.t_subst_single x y_t q in
         let assign =
           T.(t_forall_close [ y ] [] (t_implies (t_equ y_t e_t) q_sub))
         in
-        T.t_and_simp (safe_e e) assign
+        T.t_and_simp safe assign
     | ArrMake (a, n) ->
         (* a := array(n): length := n, elements := all zeros.
            safe(n) /\ 0 <= n /\ q[ a <- const 0 ][ len(a) <- n ] *)

--- a/src/hoare.ml
+++ b/src/hoare.ml
@@ -331,11 +331,17 @@ module Wlp = struct
   let proc ~machine_int ?loc g_vars q l_vars ps (t : Triple.t) =
     let p_f = Logic.translate_term ~g_vars ~l_vars t.p in
     let q_f = Logic.translate_term ~g_vars ~l_vars t.q in
+    (* An actual for a formal: an integer term, or -- for a boolean formal --
+       the boolean right-hand side's formula coerced to a [bool] term, matching
+       the [bool]-sorted formal variable. *)
+    let actual_term = function
+      | IntE e -> expr_to_term ~g_vars ~l_vars e
+      | BoolE e ->
+          T.t_if (expr_to_term ~g_vars ~l_vars e) T.t_bool_true T.t_bool_false
+    in
     let sub_params p =
       let map =
-        List.map2
-          (fun fp e -> (Vars.find fp l_vars, expr_to_term ~g_vars ~l_vars e))
-          t.ps ps
+        List.map2 (fun fp e -> (Vars.find fp l_vars, actual_term e)) t.ps ps
       in
       T.(t_subst (Mvs.of_list map) p)
     in
@@ -455,8 +461,20 @@ module Wlp = struct
             /\ forall y.
               (q_f[x_i <- e_i][x_i <- y_i][x_i@old <- x_i]
               -> q[x_i <- y_i]) *)
+        let safe_arg = function IntE e -> safe_e e | BoolE e -> safe_e e in
+        (* An actual as a term for the recursive-variant substitution: an integer
+           term, or a boolean coerced to a [bool] term (matching the formal). *)
+        let arg_term = function
+          | IntE e -> expr_to_term ~g_vars ~l_vars e
+          | BoolE e ->
+              T.t_if
+                (expr_to_term ~g_vars ~l_vars e)
+                T.t_bool_true T.t_bool_false
+        in
         let args_safe =
-          List.fold_left (fun acc e -> T.t_and_simp acc (safe_e e)) T.t_true ps
+          List.fold_left
+            (fun acc e -> T.t_and_simp acc (safe_arg e))
+            T.t_true ps
         in
         let triple, callee_l_vars = Proc_map.find f procs in
         (* Termination of recursion: if this call targets the enclosing
@@ -473,8 +491,7 @@ module Wlp = struct
               in
               let sub =
                 List.map2
-                  (fun fp e ->
-                    (Vars.find fp callee_l_vars, expr_to_term ~g_vars ~l_vars e))
+                  (fun fp e -> (Vars.find fp callee_l_vars, arg_term e))
                   triple.Triple.ps ps
               in
               let v_actuals = T.t_subst (T.Mvs.of_list sub) v_formals in

--- a/src/hoare.ml
+++ b/src/hoare.ml
@@ -139,6 +139,14 @@ let rec expr_to_term : type a.
   | Or (e, e') ->
       T.t_or (expr_to_term ~g_vars ?l_vars e) (expr_to_term ~g_vars ?l_vars e')
   | Not e -> T.t_not (expr_to_term ~g_vars ?l_vars e)
+  (* Boolean (in)equality of two formulas is (non-)equivalence. *)
+  | Beq (e, e') ->
+      T.t_iff (expr_to_term ~g_vars ?l_vars e) (expr_to_term ~g_vars ?l_vars e')
+  | Bneq (e, e') ->
+      T.t_not
+        (T.t_iff
+           (expr_to_term ~g_vars ?l_vars e)
+           (expr_to_term ~g_vars ?l_vars e'))
   | Plus (e, e') -> plus (f e) (f e')
   | Sub (e, e') -> sub (f e) (f e')
   | Mul (e, e') -> mul (f e) (f e')
@@ -208,6 +216,10 @@ let rec safe : type a.
       let self = safe ~g_vars ?l_vars ?loc in
       T.t_and_simp (self a)
         (T.t_implies_simp (T.t_not (expr_to_term ~g_vars ?l_vars a)) (self b))
+  (* [=]/[!=] evaluate both operands unconditionally. *)
+  | Beq (a, b) | Bneq (a, b) ->
+      let self = safe ~g_vars ?l_vars ?loc in
+      T.t_and_simp (self a) (self b)
   | Not a -> safe ~g_vars ?l_vars ?loc a
 
 (* Well-definedness obligation for an expression: the conjunction of
@@ -256,6 +268,9 @@ let rec defined : type a.
       let self = defined ~g_vars ?l_vars ?loc in
       T.t_and_simp (self a)
         (T.t_implies_simp (T.t_not (expr_to_term ~g_vars ?l_vars a)) (self b))
+  | Beq (a, b) | Bneq (a, b) ->
+      let self = defined ~g_vars ?l_vars ?loc in
+      T.t_and_simp (self a) (self b)
   | Not a -> defined ~g_vars ?l_vars ?loc a
 
 module Proc_map = Map.Make (String)

--- a/src/main.ml
+++ b/src/main.ml
@@ -14,9 +14,13 @@ let get_ast path =
   In_channel.close file;
   (* Reject ill-typed programs up front with a located diagnostic, and learn
      which variables are boolean so elaboration can type their occurrences. *)
-  let bools = Typecheck.check ut_ast in
-  let is_bool x = List.mem x bools in
-  List.map (Triple.translate ~is_bool) ut_ast |> Var_collection.collect
+  let { Typecheck.bool_vars; proc_bool_params } = Typecheck.check ut_ast in
+  let is_bool x = List.mem x bool_vars in
+  let proc_bool_params f =
+    match List.assoc_opt f proc_bool_params with Some bs -> bs | None -> []
+  in
+  List.map (Triple.translate ~is_bool ~proc_bool_params) ut_ast
+  |> Var_collection.collect
 
 let verify = Hoare.verify
 let verify_report = Hoare.verify_report

--- a/src/main.ml
+++ b/src/main.ml
@@ -12,10 +12,11 @@ let get_ast path =
   lexbuf.Lexing.lex_curr_p <- { lexbuf.Lexing.lex_curr_p with pos_fname = path };
   let ut_ast = Parser.top Lexer.main lexbuf in
   In_channel.close file;
-  (* Reject ill-typed programs up front with a located diagnostic, before the
-     (context-free) elaboration and the variable environment run. *)
-  Typecheck.check ut_ast;
-  List.map Triple.translate ut_ast |> Var_collection.collect
+  (* Reject ill-typed programs up front with a located diagnostic, and learn
+     which variables are boolean so elaboration can type their occurrences. *)
+  let bools = Typecheck.check ut_ast in
+  let is_bool x = List.mem x bools in
+  List.map (Triple.translate ~is_bool) ut_ast |> Var_collection.collect
 
 let verify = Hoare.verify
 let verify_report = Hoare.verify_report

--- a/test/compile.ml
+++ b/test/compile.ml
@@ -16,9 +16,9 @@ let%test_unit "Compile.emit - straight-line arithmetic" =
   (* x := 3; y := x + 4; print(y); x *)
   let body =
     Seq
-      ( Assgn ("x", Value (Int 3)),
+      ( Assgn ("x", IntE (Value (Int 3))),
         Seq
-          ( Assgn ("y", Plus (Value (VarInst "x"), Value (Int 4))),
+          ( Assgn ("y", IntE (Plus (Value (VarInst "x"), Value (Int 4)))),
             Seq (Print (Value (VarInst "y")), IntExpr (Value (VarInst "x"))) )
       )
   in
@@ -47,7 +47,9 @@ let%test_unit "Compile.emit - straight-line arithmetic" =
               (out : string)])
 
 let%test_unit "Compile.emit - result epilogue prints main's value" =
-  let body = Seq (Assgn ("x", Value (Int 1)), IntExpr (Value (VarInst "x"))) in
+  let body =
+    Seq (Assgn ("x", IntE (Value (Int 1))), IntExpr (Value (VarInst "x")))
+  in
   let out = emit_main body in
   [%test_pred: string] (contains ~substring:"let _result =") out
 
@@ -80,6 +82,20 @@ let%test_unit "Compile.emit - boolean connectives use short-circuit operators" =
   List.iter [ "&&"; "||"; "not" ] ~f:(fun substring ->
       [%test_pred: string] (contains ~substring) out)
 
+let%test_unit "Compile.emit - boolean scalar is a bool ref" =
+  (* b := 3 < 5; if b then 1 else 0 end -- the boolean global is a [bool ref]
+     initialised to [false], not an [int ref], and its read feeds the guard. *)
+  let body =
+    Seq
+      ( Assgn ("b", BoolE (Lt (Value (Int 3), Value (Int 5)))),
+        If
+          (Value (BoolVar "b"), IntExpr (Value (Int 1)), IntExpr (Value (Int 0)))
+      )
+  in
+  let out = emit_main body in
+  List.iter [ "let g_b = ref false"; "g_b :=" ] ~f:(fun substring ->
+      [%test_pred: string] (contains ~substring) out)
+
 let%test_unit "Compile.emit - while emits a Zarith-guarded loop" =
   (* while i < 10 do invariant { true } i := i + 1 end *)
   let body =
@@ -87,7 +103,7 @@ let%test_unit "Compile.emit - while emits a Zarith-guarded loop" =
       ( Logic.Bool true,
         None,
         Lt (Value (VarInst "i"), Value (Int 10)),
-        Assgn ("i", Plus (Value (VarInst "i"), Value (Int 1))) )
+        Assgn ("i", IntE (Plus (Value (VarInst "i"), Value (Int 1)))) )
   in
   let out = emit_main body in
   List.iter [ "while "; "Z.lt"; "do"; "done"; "g_i := " ] ~f:(fun substring ->
@@ -99,14 +115,14 @@ let%test_unit "Compile.emit - procedure: formals are locals, Assgn hits global"
      { true } x := 2; y := 5; f(y); x { true } *)
   let proc =
     triple ~f:"f" ~ps:[ "a" ] ~ws:[ "x" ]
-      (Assgn ("x", Plus (Value (VarInst "x"), Value (VarInst "a"))))
+      (Assgn ("x", IntE (Plus (Value (VarInst "x"), Value (VarInst "a")))))
   in
   let main =
     triple
       (Seq
-         ( Assgn ("x", Value (Int 2)),
+         ( Assgn ("x", IntE (Value (Int 2))),
            Seq
-             ( Assgn ("y", Value (Int 5)),
+             ( Assgn ("y", IntE (Value (Int 5))),
                Seq
                  ( Proc ("f", [ Value (VarInst "y") ]),
                    IntExpr (Value (VarInst "x")) ) ) ))
@@ -127,7 +143,7 @@ let%test_unit "Compile.emit - procedure: formals are locals, Assgn hits global"
           [%message "missing fragment" (substring : string) (out : string)])
 
 let%test_unit "Compile.emit - zero-arg procedure takes unit" =
-  let proc = triple ~f:"f" (Assgn ("y", Value (Int 1))) in
+  let proc = triple ~f:"f" (Assgn ("y", IntE (Value (Int 1)))) in
   let main = triple (Proc ("f", [])) in
   let out = Var_collection.collect [ proc; main ] |> Cavalry.Compile.emit in
   List.iter [ "let rec p_f () ="; "(p_f ())" ] ~f:(fun substring ->

--- a/test/compile.ml
+++ b/test/compile.ml
@@ -124,7 +124,7 @@ let%test_unit "Compile.emit - procedure: formals are locals, Assgn hits global"
            Seq
              ( Assgn ("y", IntE (Value (Int 5))),
                Seq
-                 ( Proc ("f", [ Value (VarInst "y") ]),
+                 ( Proc ("f", [ IntE (Value (VarInst "y")) ]),
                    IntExpr (Value (VarInst "x")) ) ) ))
   in
   let out = Var_collection.collect [ proc; main ] |> Cavalry.Compile.emit in

--- a/test/dune
+++ b/test/dune
@@ -80,6 +80,7 @@
    verify_true_annotated_proc.cav
    verify_true_bool_scalar.cav
    verify_true_bool_flag.cav
+   verify_true_bool_eq.cav
    type_error_bool_arith.cav
    type_error_var_guard.cav
    verify_false_writes_undeclared.cav

--- a/test/dune
+++ b/test/dune
@@ -85,6 +85,8 @@
    verify_false_bool_spec.cav
    verify_true_bool_invariant.cav
    verify_true_bool_param.cav
+   verify_true_bool_copy.cav
+   type_error_bool_in_assertion.cav
    type_error_bool_arith.cav
    type_error_var_guard.cav
    verify_false_writes_undeclared.cav

--- a/test/dune
+++ b/test/dune
@@ -81,6 +81,9 @@
    verify_true_bool_scalar.cav
    verify_true_bool_flag.cav
    verify_true_bool_eq.cav
+   verify_true_bool_spec.cav
+   verify_false_bool_spec.cav
+   verify_true_bool_invariant.cav
    type_error_bool_arith.cav
    type_error_var_guard.cav
    verify_false_writes_undeclared.cav

--- a/test/dune
+++ b/test/dune
@@ -78,6 +78,10 @@
    type_error_arity.cav
    type_error_bool_param.cav
    verify_true_annotated_proc.cav
+   verify_true_bool_scalar.cav
+   verify_true_bool_flag.cav
+   type_error_bool_arith.cav
+   type_error_var_guard.cav
    verify_false_writes_undeclared.cav
    verify_false_loop_unquantified.cav
    compile_overflow.cav

--- a/test/dune
+++ b/test/dune
@@ -84,6 +84,7 @@
    verify_true_bool_spec.cav
    verify_false_bool_spec.cav
    verify_true_bool_invariant.cav
+   verify_true_bool_param.cav
    type_error_bool_arith.cav
    type_error_var_guard.cav
    verify_false_writes_undeclared.cav

--- a/test/fuzz/fuzz.ml
+++ b/test/fuzz/fuzz.ml
@@ -463,6 +463,7 @@ let rec arith_to_cav = function
    comparisons this harness generates for P and Q. *)
 let rec logic_to_cav = function
   | Logic.Bool b -> string_of_bool b
+  | Logic.BoolVar x -> x
   | Logic.Not e -> Printf.sprintf "!%s" (logic_to_cav e)
   | Logic.And (a, b) ->
       Printf.sprintf "%s && %s" (logic_to_cav a) (logic_to_cav b)

--- a/test/fuzz/fuzz.ml
+++ b/test/fuzz/fuzz.ml
@@ -138,7 +138,7 @@ let gen_invariant =
     ]
 
 let gen_assgn =
-  G.map2 (fun x e -> Program.Assgn (x, e)) gen_var (gen_int_expr 3)
+  G.map2 (fun x e -> Program.Assgn (x, Program.IntE e)) gen_var (gen_int_expr 3)
 
 (* Loop-free command generator: assignments, sequencing, conditionals. Used for
    the dual (true-postcondition) property, where WLP is exact and the solver
@@ -180,9 +180,11 @@ let gen_while =
       G.bind gen_invariant (fun inv ->
           G.map2
             (fun t e ->
-              let decr = Assgn (c, Sub (Value (VarInst c), Value (Int 1))) in
+              let decr =
+                Assgn (c, IntE (Sub (Value (VarInst c), Value (Int 1))))
+              in
               let guard = Gt (Value (VarInst c), Value (Int 0)) in
-              While (inv, None, guard, Seq (Assgn (t, e), decr)))
+              While (inv, None, guard, Seq (Assgn (t, IntE e), decr)))
             (G.oneof_list others) (gen_int_expr 3)))
 
 (* Full command generator: adds shallow, rare [While] loops. Used for the
@@ -226,7 +228,8 @@ let gen_case gen_cmd = G.pair gen_s0 (G.sized_size (G.int_range 2 6) gen_cmd)
 let seed_cmd s0 c =
   List.fold_right
     (fun (x, v) acc ->
-      Program.Seq (Program.Assgn (x, Program.Value (Program.Int v)), acc))
+      Program.Seq
+        (Program.Assgn (x, Program.IntE (Program.Value (Program.Int v))), acc))
     s0 c
 
 let run s0 c =
@@ -288,7 +291,7 @@ let gen_framing =
 
 let framing_body hidden kh roles =
   let open Program in
-  let assign v k = Assgn (v, Plus (Value (VarInst v), Value (Int k))) in
+  let assign v k = Assgn (v, IntE (Plus (Value (VarInst v), Value (Int k)))) in
   let stmts =
     assign hidden kh
     :: List.filter_map
@@ -402,6 +405,7 @@ let value_to_cav : type a. a Program.value -> string = function
   | Program.Int i -> string_of_int i
   | Program.Bool b -> string_of_bool b
   | Program.VarInst x -> x
+  | Program.BoolVar x -> x
   | Program.Unit () -> "()"
 
 let rec expr_to_cav : type a. a Program.expr -> string =
@@ -477,11 +481,15 @@ let rec logic_to_cav = function
   | Logic.Forall (x, e) -> Printf.sprintf "forall %s . %s" x (logic_to_cav e)
   | Logic.Exists (x, e) -> Printf.sprintf "exists %s . %s" x (logic_to_cav e)
 
+let any_to_cav = function
+  | Program.IntE e -> expr_to_cav e
+  | Program.BoolE e -> expr_to_cav e
+
 let rec cmd_to_cav c =
   match c with
   | Program.Located (_, c) -> cmd_to_cav c
-  | Program.Assgn (x, e) -> Printf.sprintf "%s := %s" x (expr_to_cav e)
-  | Program.Let (x, e) -> Printf.sprintf "%s := %s" x (expr_to_cav e)
+  | Program.Assgn (x, e) -> Printf.sprintf "%s := %s" x (any_to_cav e)
+  | Program.Let (x, e) -> Printf.sprintf "%s := %s" x (any_to_cav e)
   | Program.Seq (a, b) -> Printf.sprintf "%s;\n%s" (cmd_to_cav a) (cmd_to_cav b)
   | Program.If (b, c0, c1) ->
       Printf.sprintf "if %s then\n%s\nelse\n%s\nend" (expr_to_cav b)

--- a/test/fuzz/fuzz.ml
+++ b/test/fuzz/fuzz.ml
@@ -433,6 +433,10 @@ let rec expr_to_cav : type a. a Program.expr -> string =
   | Program.Or (a, b) ->
       Printf.sprintf "(%s || %s)" (expr_to_cav a) (expr_to_cav b)
   | Program.Not a -> Printf.sprintf "(! %s)" (expr_to_cav a)
+  | Program.Beq (a, b) ->
+      Printf.sprintf "(%s = %s)" (expr_to_cav a) (expr_to_cav b)
+  | Program.Bneq (a, b) ->
+      Printf.sprintf "(%s != %s)" (expr_to_cav a) (expr_to_cav b)
   | Program.Get (a, i) -> Printf.sprintf "%s[%s]" a (expr_to_cav i)
   | Program.Len a -> Printf.sprintf "len(%s)" a
 

--- a/test/fuzz/fuzz.ml
+++ b/test/fuzz/fuzz.ml
@@ -510,7 +510,7 @@ let rec cmd_to_cav c =
         (expr_to_cav b) (logic_to_cav inv) variant_clause
         (indent 2 (cmd_to_cav body))
   | Program.Proc (f, ps) ->
-      Printf.sprintf "%s(%s)" f (String.concat ", " (List.map expr_to_cav ps))
+      Printf.sprintf "%s(%s)" f (String.concat ", " (List.map any_to_cav ps))
   | Program.IntExpr e -> expr_to_cav e
   | Program.Print e -> Printf.sprintf "print %s" (expr_to_cav e)
   | Program.ArrMake (a, n) -> Printf.sprintf "%s := array(%s)" a (expr_to_cav n)

--- a/test/integration.ml
+++ b/test/integration.ml
@@ -536,6 +536,13 @@ let%test_unit "Main.verify true boolean scalar" =
 let%test_unit "Main.verify true boolean flag loop" =
   check_verify "verify_true_bool_flag.cav" Valid
 
+(* Boolean equality [p = q] between two boolean variables. *)
+let%test_unit "Main.verify true boolean equality" =
+  check_verify "verify_true_bool_eq.cav" Valid
+
+let%test_unit "Main.exec boolean equality" =
+  [%test_result: int] (Main.exec "verify_true_bool_eq.cav") ~expect:1
+
 (* The same boolean-scalar program runs to a concrete result (x = 5 >= 0, so the
    [else] branch gives y = x = 5). *)
 let%test_unit "Main.exec boolean scalar" =

--- a/test/integration.ml
+++ b/test/integration.ml
@@ -480,7 +480,7 @@ let%test_unit "Main.get_ast type error if guard" =
   in
   [%test_result: bool] raised ~expect:true
 
-(* Assignment RHS must be an int expr; `1 < 2` is boolean. *)
+(* A variable fixed as an integer cannot later be assigned a boolean. *)
 let%test_unit "Main.get_ast type error assign bool" =
   let raised =
     Exn.does_raise (fun () -> Main.get_ast "type_error_assign_bool.cav")
@@ -513,9 +513,33 @@ let%test_unit "Main.get_ast type error bool parameter" =
   check_type_error ~substring:"only integer parameters"
     "type_error_bool_param.cav"
 
+(* A boolean variable used in arithmetic. *)
+let%test_unit "Main.get_ast type error boolean in arithmetic" =
+  check_type_error ~substring:"expected int but got bool"
+    "type_error_bool_arith.cav"
+
+(* An integer variable used as a loop guard. *)
+let%test_unit "Main.get_ast type error integer guard variable" =
+  check_type_error ~substring:"expected bool but got int"
+    "type_error_var_guard.cav"
+
 (* Optional int parameter annotations are accepted and the program verifies. *)
 let%test_unit "Main.verify true annotated procedure" =
   check_verify "verify_true_annotated_proc.cav" Valid
+
+(* A boolean scalar variable inferred from its comparison RHS and used as an
+   [if] guard. *)
+let%test_unit "Main.verify true boolean scalar" =
+  check_verify "verify_true_bool_scalar.cav" Valid
+
+(* A boolean flag driving a loop guard, with a variant for total correctness. *)
+let%test_unit "Main.verify true boolean flag loop" =
+  check_verify "verify_true_bool_flag.cav" Valid
+
+(* The same boolean-scalar program runs to a concrete result (x = 5 >= 0, so the
+   [else] branch gives y = x = 5). *)
+let%test_unit "Main.exec boolean scalar" =
+  [%test_result: int] (Main.exec "verify_true_bool_scalar.cav") ~expect:5
 
 (* ===== Prover answer -> result mapping (stubbed, no real solver call) ===== *)
 

--- a/test/integration.ml
+++ b/test/integration.ml
@@ -543,6 +543,17 @@ let%test_unit "Main.verify true boolean equality" =
 let%test_unit "Main.exec boolean equality" =
   [%test_result: int] (Main.exec "verify_true_bool_eq.cav") ~expect:1
 
+(* A boolean variable named in the postcondition and in a loop invariant. *)
+let%test_unit "Main.verify true boolean in spec" =
+  check_verify "verify_true_bool_spec.cav" Valid
+
+let%test_unit "Main.verify true boolean in invariant" =
+  check_verify "verify_true_bool_invariant.cav" Valid
+
+(* A false boolean postcondition is caught. *)
+let%test_unit "Main.verify false boolean in spec" =
+  check_verify "verify_false_bool_spec.cav" Invalid
+
 (* The same boolean-scalar program runs to a concrete result (x = 5 >= 0, so the
    [else] branch gives y = x = 5). *)
 let%test_unit "Main.exec boolean scalar" =

--- a/test/integration.ml
+++ b/test/integration.ml
@@ -523,6 +523,12 @@ let%test_unit "Main.get_ast type error integer guard variable" =
   check_type_error ~substring:"expected bool but got int"
     "type_error_var_guard.cav"
 
+(* Assertions are type-checked: a boolean used in arithmetic inside a
+   postcondition is rejected. *)
+let%test_unit "Main.get_ast type error boolean in assertion" =
+  check_type_error ~substring:"in an assertion"
+    "type_error_bool_in_assertion.cav"
+
 (* Optional int parameter annotations are accepted and the program verifies. *)
 let%test_unit "Main.verify true annotated procedure" =
   check_verify "verify_true_annotated_proc.cav" Valid
@@ -557,6 +563,10 @@ let%test_unit "Main.verify false boolean in spec" =
 (* A boolean procedure parameter, referenced in the callee's contract. *)
 let%test_unit "Main.verify true boolean parameter" =
   check_verify "verify_true_bool_param.cav" Valid
+
+(* A variable copied from a boolean is inferred boolean ([same := pos]). *)
+let%test_unit "Main.verify true boolean copy" =
+  check_verify "verify_true_bool_copy.cav" Valid
 
 (* The same boolean-scalar program runs to a concrete result (x = 5 >= 0, so the
    [else] branch gives y = x = 5). *)

--- a/test/integration.ml
+++ b/test/integration.ml
@@ -508,9 +508,9 @@ let%test_unit "Main.get_ast type error undeclared procedure" =
 let%test_unit "Main.get_ast type error call arity" =
   check_type_error ~substring:"argument" "type_error_arity.cav"
 
-(* Only integer parameters are supported, so a bool-annotated one is rejected. *)
-let%test_unit "Main.get_ast type error bool parameter" =
-  check_type_error ~substring:"only integer parameters"
+(* A parameter annotated int but used as a boolean is a type error. *)
+let%test_unit "Main.get_ast type error parameter annotation mismatch" =
+  check_type_error ~substring:"annotated int but used as a boolean"
     "type_error_bool_param.cav"
 
 (* A boolean variable used in arithmetic. *)
@@ -553,6 +553,10 @@ let%test_unit "Main.verify true boolean in invariant" =
 (* A false boolean postcondition is caught. *)
 let%test_unit "Main.verify false boolean in spec" =
   check_verify "verify_false_bool_spec.cav" Invalid
+
+(* A boolean procedure parameter, referenced in the callee's contract. *)
+let%test_unit "Main.verify true boolean parameter" =
+  check_verify "verify_true_bool_param.cav" Valid
 
 (* The same boolean-scalar program runs to a concrete result (x = 5 >= 0, so the
    [else] branch gives y = x = 5). *)

--- a/test/program.ml
+++ b/test/program.ml
@@ -15,12 +15,18 @@ let rec equal_expr : type a. a expr -> a expr -> bool =
   | Mul (e0, e0'), Mul (e1, e1') -> equal_expr e0 e1 && equal_expr e0' e1'
   | _, _ -> false
 
+let equal_any (a0 : anyexpr) (a1 : anyexpr) =
+  match (a0, a1) with
+  | IntE e0, IntE e1 -> equal_expr e0 e1
+  | BoolE e0, BoolE e1 -> equal_expr e0 e1
+  | _ -> false
+
 let rec equal_cmd : cmd -> cmd -> bool =
  fun e0 e1 ->
   match (e0, e1) with
   | IntExpr e0, IntExpr e1 -> equal_expr e0 e1
   | Seq (e0, e0'), Seq (e1, e1') -> equal_cmd e0 e1 && equal_cmd e0' e1'
-  | Assgn (s0, e0), Assgn (s1, e1) -> String.equal s0 s1 && equal_expr e0 e1
+  | Assgn (s0, e0), Assgn (s1, e1) -> String.equal s0 s1 && equal_any e0 e1
   | If (e0, e0', e0''), If (e1, e1', e1'') ->
       equal_expr e0 e1 && equal_cmd e0' e1' && equal_cmd e0'' e1''
   | _, _ -> false
@@ -43,7 +49,7 @@ let%test_unit "Ast.Program.type_expr" =
   (* x := 1 + 2; if 1 = 2 then 5 else x * 5 end *)
   let expected =
     Seq
-      ( Assgn ("x", Plus (Value (Int 1), Value (Int 2))),
+      ( Assgn ("x", IntE (Plus (Value (Int 1), Value (Int 2)))),
         If
           ( Eq (Value (Int 1), Value (Int 2)),
             IntExpr (Value (Int 5)),
@@ -54,14 +60,14 @@ let%test_unit "Ast.Program.type_expr" =
       ( UAssgn ("x", UPlus (UInt 1, UInt 2)),
         UIf (UEq (UInt 1, UInt 2), UInt 5, UMul (UVar "x", UInt 5)) )
   in
-  let result = translate_cmd ut in
+  let result = translate_cmd ~is_bool:(fun _ -> false) ut in
   test_ast_eq ~expected result
 
 let%test_unit "Ast.Runtime.exec - assgn" =
   (* x := 1 + 2; x * 5 *)
   let c =
     Seq
-      ( Assgn ("x", Plus (Value (Int 1), Value (Int 2))),
+      ( Assgn ("x", IntE (Plus (Value (Int 1), Value (Int 2)))),
         IntExpr (Mul (Value (VarInst "x"), Value (Int 5))) )
   in
   let main = { f = ""; ps = []; c } in
@@ -84,9 +90,9 @@ let%test_unit "Ast.Runtime.exec - var-var-assgn" =
   (* x := 1; y := x + 2; y *)
   let c =
     Seq
-      ( Assgn ("x", Value (Int 1)),
+      ( Assgn ("x", IntE (Value (Int 1))),
         Seq
-          ( Assgn ("y", Plus (Value (VarInst "x"), Value (Int 2))),
+          ( Assgn ("y", IntE (Plus (Value (VarInst "x"), Value (Int 2)))),
             IntExpr (Value (VarInst "y")) ) )
   in
   let main = { f = ""; ps = []; c } in
@@ -105,9 +111,9 @@ let%test_unit "Ast.Runtime.exec - while" =
   (* x := 0; i := 0; while i < 10 do x := x + i; i := i + 1 end; x *)
   let c =
     Seq
-      ( Assgn ("x", Value (Int 0)),
+      ( Assgn ("x", IntE (Value (Int 0))),
         Seq
-          ( Assgn ("i", Value (Int 0)),
+          ( Assgn ("i", IntE (Value (Int 0))),
             Seq
               ( While
                   ( dummy_invariant,
@@ -115,8 +121,12 @@ let%test_unit "Ast.Runtime.exec - while" =
                     Lt (Value (VarInst "i"), Value (Int 10)),
                     Seq
                       ( Assgn
-                          ("x", Plus (Value (VarInst "x"), Value (VarInst "i"))),
-                        Assgn ("i", Plus (Value (VarInst "i"), Value (Int 1)))
+                          ( "x",
+                            IntE
+                              (Plus (Value (VarInst "x"), Value (VarInst "i")))
+                          ),
+                        Assgn
+                          ("i", IntE (Plus (Value (VarInst "i"), Value (Int 1))))
                       ) ),
                 IntExpr (Value (VarInst "x")) ) ) )
   in
@@ -132,17 +142,20 @@ let dummy_invariant = Logic.(Eq (Int 1, Int 2))
 let%test_unit "Ast.Runtime.exec_env - terminating loop returns final env" =
   let c =
     Seq
-      ( Assgn ("x", Value (Int 0)),
+      ( Assgn ("x", IntE (Value (Int 0))),
         Seq
-          ( Assgn ("i", Value (Int 0)),
+          ( Assgn ("i", IntE (Value (Int 0))),
             While
               ( dummy_invariant,
                 None,
                 Lt (Value (VarInst "i"), Value (Int 3)),
                 Seq
-                  ( Assgn ("x", Plus (Value (VarInst "x"), Value (VarInst "i"))),
-                    Assgn ("i", Plus (Value (VarInst "i"), Value (Int 1))) ) )
-          ) )
+                  ( Assgn
+                      ( "x",
+                        IntE (Plus (Value (VarInst "x"), Value (VarInst "i")))
+                      ),
+                    Assgn ("i", IntE (Plus (Value (VarInst "i"), Value (Int 1))))
+                  ) ) ) )
   in
   match exec_env ~fuel:100 [ { f = ""; ps = []; c } ] with
   | Terminated env ->
@@ -155,12 +168,12 @@ let%test_unit "Ast.Runtime.exec_env - terminating loop returns final env" =
 let%test_unit "Ast.Runtime.exec_env - non-terminating loop runs out of fuel" =
   let c =
     Seq
-      ( Assgn ("i", Value (Int 0)),
+      ( Assgn ("i", IntE (Value (Int 0))),
         While
           ( dummy_invariant,
             None,
             Lt (Value (Int 0), Value (Int 1)),
-            Assgn ("i", Plus (Value (VarInst "i"), Value (Int 1))) ) )
+            Assgn ("i", IntE (Plus (Value (VarInst "i"), Value (Int 1)))) ) )
   in
   let out_of_fuel =
     match exec_env ~fuel:50 [ { f = ""; ps = []; c } ] with
@@ -213,7 +226,9 @@ let%test_unit "Ast.Runtime.exec - function" =
     }
   in
   let program ret =
-    List.map [ fn; main ret ] ~f:(fun ut -> Triple.translate ut |> to_proc_t)
+    List.map
+      [ fn; main ret ]
+      ~f:(fun ut -> Triple.translate ~is_bool:(fun _ -> false) ut |> to_proc_t)
   in
   let result = exec (program "x") in
   [%test_result: int] result ~expect:8;

--- a/test/program.ml
+++ b/test/program.ml
@@ -60,7 +60,9 @@ let%test_unit "Ast.Program.type_expr" =
       ( UAssgn ("x", UPlus (UInt 1, UInt 2)),
         UIf (UEq (UInt 1, UInt 2), UInt 5, UMul (UVar "x", UInt 5)) )
   in
-  let result = translate_cmd ~is_bool:(fun _ -> false) ut in
+  let result =
+    translate_cmd ~is_bool:(fun _ -> false) ~proc_bool_params:(fun _ -> []) ut
+  in
   test_ast_eq ~expected result
 
 let%test_unit "Ast.Runtime.exec - assgn" =
@@ -228,7 +230,14 @@ let%test_unit "Ast.Runtime.exec - function" =
   let program ret =
     List.map
       [ fn; main ret ]
-      ~f:(fun ut -> Triple.translate ~is_bool:(fun _ -> false) ut |> to_proc_t)
+      ~f:(fun ut ->
+        (* [f] takes one integer parameter. *)
+        Triple.translate
+          ~is_bool:(fun _ -> false)
+          ~proc_bool_params:(fun name ->
+            if String.equal name "f" then [ false ] else [])
+          ut
+        |> to_proc_t)
   in
   let result = exec (program "x") in
   [%test_result: int] result ~expect:8;

--- a/test/type_error_assign_bool.cav
+++ b/test/type_error_assign_bool.cav
@@ -1,3 +1,7 @@
+// `x` is fixed as an integer by `x := 5`, so later assigning it a boolean
+// (`1 < 2`) is a type error. (A variable whose first/only assignment is boolean
+// is instead inferred boolean -- see verify_true_bool_flag.cav.)
 { true }
+x := 5;
 x := 1 < 2
 { true }

--- a/test/type_error_bool_arith.cav
+++ b/test/type_error_bool_arith.cav
@@ -1,0 +1,6 @@
+// `b` is boolean (assigned a comparison), so using it in arithmetic is a type
+// error.
+{ true }
+b := 1 < 2;
+x := b + 1
+{ true }

--- a/test/type_error_bool_in_assertion.cav
+++ b/test/type_error_bool_in_assertion.cav
@@ -1,0 +1,6 @@
+// Assertions are type-checked too: b is boolean, so using it in arithmetic
+// inside the postcondition is a type error.
+{ true }
+b := 1 < 2;
+x := 3
+{ b + 1 = 2 }

--- a/test/type_error_bool_param.cav
+++ b/test/type_error_bool_param.cav
@@ -1,10 +1,15 @@
-// Parameter annotations are validated: only integer parameters are supported,
-// so a `bool`-annotated parameter is rejected (boolean variables are a later
-// milestone).
-procedure f (a: bool) =
-  requires { true } ensures { true } writes { }
-  x := 1
+// The parameter is annotated int but used as a boolean (an if-guard): the
+// annotation contradicts the inferred type. (Boolean parameters themselves are
+// supported -- see verify_true_bool_param.cav.)
+procedure f (a: int) =
+  requires { true } ensures { true } writes { x }
+  if a then
+    x := 1
+  else
+    x := 2
+  end
 end
 { true }
-x := 0
+x := 0;
+f(1)
 { true }

--- a/test/type_error_var_guard.cav
+++ b/test/type_error_var_guard.cav
@@ -1,0 +1,9 @@
+// A loop guard must be boolean; `x` is an integer variable, so `while x` is a
+// type error.
+{ true }
+x := 5;
+while x do
+  invariant { true }
+  x := x - 1
+end
+{ true }

--- a/test/verify_false_bool_spec.cav
+++ b/test/verify_false_bool_spec.cav
@@ -1,0 +1,5 @@
+// x < 0, so pos is false, but the postcondition asserts pos: verification fails.
+{ true }
+x := 0 - 5;
+pos := x > 0
+{ pos }

--- a/test/verify_true_bool_copy.cav
+++ b/test/verify_true_bool_copy.cav
@@ -1,0 +1,7 @@
+// A variable copied from a boolean is itself inferred boolean: [same := pos]
+// makes [same] boolean, so it can be named in the postcondition.
+{ true }
+x := 5;
+pos := x > 0;
+same := pos
+{ same }

--- a/test/verify_true_bool_eq.cav
+++ b/test/verify_true_bool_eq.cav
@@ -1,0 +1,13 @@
+// Boolean equality: p and q are both true (x = 5 is > 0 and > 3), so p = q
+// takes the first branch. Verifiable and runnable.
+{ true }
+x := 5;
+p := x > 0;
+q := x > 3;
+if p = q then
+  r := 1
+else
+  r := 2
+end;
+r
+{ r = 1 }

--- a/test/verify_true_bool_flag.cav
+++ b/test/verify_true_bool_flag.cav
@@ -1,0 +1,15 @@
+// A boolean flag in a loop guard: [found] is set when the value is located, and
+// [!found] short-circuits the guard. [i] increments every iteration so the
+// variant [n - i] still decreases (total correctness).
+{ n >= 0 && n <= len(a) }
+i := 0;
+found := false;
+while i < n && !found do
+  invariant { 0 <= i && i <= n && n <= len(a) }
+  variant { n - i }
+  if a[i] = x then
+    found := true
+  end;
+  i := i + 1
+end
+{ 0 <= i && i <= n }

--- a/test/verify_true_bool_invariant.cav
+++ b/test/verify_true_bool_invariant.cav
@@ -1,0 +1,11 @@
+// A boolean variable in a loop invariant (and the postcondition): [ok] stays
+// true across the loop.
+{ n >= 0 }
+i := 0;
+ok := true;
+while i < n do
+  invariant { ok && 0 <= i && i <= n }
+  variant { n - i }
+  i := i + 1
+end
+{ ok }

--- a/test/verify_true_bool_param.cav
+++ b/test/verify_true_bool_param.cav
@@ -1,0 +1,17 @@
+// A boolean procedure parameter, named in the contract: [cond] is annotated
+// bool, used as a guard, and constrains the postcondition. The call passes a
+// boolean argument.
+procedure set_if (cond: bool) =
+  requires { true }
+  ensures { cond -> r = 1 }
+  writes { r }
+  if cond then
+    r := 1
+  else
+    r := 0
+  end
+end
+{ true }
+r := 0;
+set_if(1 < 2)
+{ r = 1 }

--- a/test/verify_true_bool_scalar.cav
+++ b/test/verify_true_bool_scalar.cav
@@ -1,0 +1,12 @@
+// A boolean scalar variable: [neg] is inferred boolean from its comparison
+// right-hand side, then used as an [if] guard. Runnable and verifiable.
+{ true }
+x := 5;
+neg := x < 0;
+if neg then
+  y := 0 - x
+else
+  y := x
+end;
+y
+{ y = 5 }

--- a/test/verify_true_bool_spec.cav
+++ b/test/verify_true_bool_spec.cav
@@ -1,0 +1,6 @@
+// A boolean variable named in the postcondition: [pos] records x > 0, and the
+// spec asserts it holds.
+{ true }
+x := 5;
+pos := x > 0
+{ pos }


### PR DESCRIPTION
First-class boolean variables, built on the type checker from milestone 3, now covering the full boolean surface (scalars).

Boolean *expressions* (comparisons, `&&`/`||`/`!`) already existed, but a *variable* was always an integer. This makes booleans first-class:

```
neg := x < 0;              // inferred boolean from its comparison RHS
same := neg;               // and along copies
if same then y := 0 - x else y := x end

procedure set_if (cond: bool) =           // boolean parameter,
  ensures { cond -> r = 1 } writes { r }  // constrained in the contract
  if cond then r := 1 else r := 0 end
end
```

## Commits

1. **first-class boolean variables** — `BoolVar` in the value GADT, an `anyexpr` tag on assignment RHS, `is_bool`-driven elaboration, `bool`-sorted Why3 symbols, and the `bool`-sort/`Prop` bridge (a boolean variable coerced `= True` in formula position, coerced back with `t_if` when assigned). Interpreter stores 0/1; compiler emits real `bool ref`s. Inference: a variable forced boolean by a boolean context, no annotation required.
2. **boolean equality** — `=`/`!=` accept boolean operands (`p = q`); the checker requires matching operand types, and the WLP uses `t_iff`.
3. **boolean variables in specifications** — a bare variable in an assertion parses to `Logic.BoolVar` (`{ pos }`, `{ !done -> ... }`, `ok && 0 <= i` in an invariant); boolean equality in an assertion picks `t_equ` by operand sort. The grammar addition is LR(1) conflict-free.
4. **boolean procedure parameters** — `Proc` arguments carry a type, elaborated at the callee's parameter types (`Typecheck` returns per-procedure parameter-boolean info); the WLP coerces boolean actuals to `bool` terms for the contract and recursive-variant substitutions.
5. **type-check assertions and infer copied booleans** — `Typecheck` now types the logic language (pre/postconditions, invariants, variant measures), so a malformed assertion (a boolean in arithmetic, an integer named as a bare proposition, `len` of a non-array) is a diagnostic rather than a Why3 sort error; and a variable copied from a boolean (`y := b`) is inferred boolean by saturating copy edges to a fixpoint.

## Scope

Booleans are complete for scalars: variables, equality, guards, specifications, parameters, and copy inference, through interpret / verify / native compile, with assertions type-checked. **Boolean arrays** remain out of scope as a separate feature (a different axis from boolean scalars).

## Testing

Behaviour-preserving: every existing fixture, README snippet, and `example.cav` verifies unchanged. `dune build`, `@fmt`, `runtest`, and `@doc` all pass. Verified end-to-end (verify / run / native compile agree) for boolean scalars, a flag-driven search loop, boolean equality, boolean variables in postconditions and invariants, boolean parameters constrained in a procedure contract, and boolean copies, plus type-error fixtures for every rejected case (boolean in arithmetic, integer variable as a guard, cross-type assignment, mixed equality, annotation mismatch, and a malformed assertion).