### PR TITLE
feat: boolean arrays

### DIFF
--- a/src/ast/arith.ml
+++ b/src/ast/arith.ml
@@ -27,6 +27,8 @@ type defs = {
   const_symbol : Term.lsymbol;
   ty_int_map : Ty.ty;
   azero : Term.term;
+  ty_int_bool_map : Ty.ty;
+  bfalse : Term.term;
   min_int : Term.term;
   max_int : Term.term;
   base_task : Task.task;
@@ -59,6 +61,13 @@ let defs =
      let get_symbol = find_symbol map_theory "get" in
      let const_symbol = find_symbol const_theory "const" in
      let azero = T.t_app const_symbol [ T.t_nat_const 0 ] (Some ty_int_map) in
+     (* Boolean arrays are [map int bool]; an [array(n)] of booleans starts from
+        the all-[False] map. The [map.Map]/[map.Const] symbols are polymorphic,
+        so the same [get]/[set]/[const] serve both element types. *)
+     let ty_int_bool_map = Ty.ty_app map_ts [ Ty.ty_int; Ty.ty_bool ] in
+     let bfalse =
+       T.t_app const_symbol [ T.t_bool_false ] (Some ty_int_bool_map)
+     in
      let sub_symbol = find_symbol int_theory "infix -" in
      let sub a b = T.t_app sub_symbol [ a; b ] (Some Ty.ty_int) in
      (* Machine-integer range. OCaml native [int] is 63-bit ([Sys.int_size =
@@ -111,6 +120,8 @@ let defs =
        const_symbol;
        ty_int_map;
        azero;
+       ty_int_bool_map;
+       bfalse;
        min_int;
        max_int;
        base_task;
@@ -133,11 +144,20 @@ let geq a b = T.ps_app (d ()).geq_symbol [ a; b ]
 let aget a i = T.t_app (d ()).get_symbol [ a; i ] (Some Ty.ty_int)
 let aset a i v = T.t_app (d ()).set_symbol [ a; i; v ] (Some (d ()).ty_int_map)
 
+(* The boolean-array counterparts: [a[i]] as a [bool] term and [set a i v] over a
+   [map int bool]. *)
+let aget_bool a i = T.t_app (d ()).get_symbol [ a; i ] (Some Ty.ty_bool)
+
+let aset_bool a i v =
+  T.t_app (d ()).set_symbol [ a; i; v ] (Some (d ()).ty_int_bool_map)
+
 (* Exposed as [Lazy.t] rather than plain values: a consumer that bound one of
    these at its own top level would re-force the whole Why3 layer at startup,
    the very cost the laziness above avoids. Callers force at use. *)
 let ty_int_map = lazy (d ()).ty_int_map
 let azero = lazy (d ()).azero
+let ty_int_bool_map = lazy (d ()).ty_int_bool_map
+let bfalse = lazy (d ()).bfalse
 let min_int = lazy (d ()).min_int
 let max_int = lazy (d ()).max_int
 

--- a/src/ast/arith.mli
+++ b/src/ast/arith.mli
@@ -31,15 +31,27 @@ val ty_int_map : Ty.ty Lazy.t
     {!min_int}). *)
 
 val aget : Term.term -> Term.term -> Term.term
-(** [aget a i] is the element [a[i]] ([map.Map]'s [get]). *)
+(** [aget a i] is the element [a[i]] ([map.Map]'s [get]) of an integer array. *)
+
+val aget_bool : Term.term -> Term.term -> Term.term
+(** [aget a i] for a boolean array: a [bool]-sorted element term. *)
 
 val aset : Term.term -> Term.term -> Term.term -> Term.term
 (** [aset a i v] is the array [a] with index [i] updated to [v] ([map.Map]'s
     [set]); other indices and the separately-tracked length are unchanged. *)
 
+val aset_bool : Term.term -> Term.term -> Term.term -> Term.term
+(** [aset a i v] for a boolean array (over a [map int bool]). *)
+
 val azero : Term.term Lazy.t
 (** The all-zeros element store an [array(n)] begins from ([map.Const]'s
     [const 0]). Lazy for the same reason as {!ty_int_map}. *)
+
+val ty_int_bool_map : Ty.ty Lazy.t
+(** The Why3 type of a boolean array's element store: [map int bool]. *)
+
+val bfalse : Term.term Lazy.t
+(** The all-[False] element store a boolean [array(n)] begins from. *)
 
 val eq : Term.term -> Term.term -> Term.term
 val neq : Term.term -> Term.term -> Term.term

--- a/src/ast/logic.ml
+++ b/src/ast/logic.ml
@@ -16,6 +16,8 @@ type arith_expr =
 type logic_expr =
   | Bool of bool
   | BoolVar of string (* a boolean program variable as a proposition *)
+  | BGet of
+      string * arith_expr (* a boolean array element a[i] as a proposition *)
   | Not of logic_expr
   | And of logic_expr * logic_expr
   | Or of logic_expr * logic_expr
@@ -57,7 +59,16 @@ let rec translate_arith_term ~g_vars ?l_vars ?(bound = Vars.empty) e =
   | Mul (e0, e1) -> Arith.mul (f e0) (f e1)
   | Div (e0, e1) -> Arith.div (f e0) (f e1)
   | Mod (e0, e1) -> Arith.modulo (f e0) (f e1)
-  | Get (a, i) -> Arith.aget (var a) (f i)
+  (* [a[i]] uses the boolean [get] when [a] is a boolean array, so its element
+     is [bool]-sorted (used by [=]/[!=] over booleans below). *)
+  | Get (a, i) ->
+      let av = resolve ~g_vars ?l_vars ~bound a in
+      let get =
+        if Why3.Ty.ty_equal av.T.vs_ty (Lazy.force Arith.ty_int_bool_map) then
+          Arith.aget_bool
+        else Arith.aget
+      in
+      get (T.t_var av) (f i)
   | Len a -> var (Vars.len_key a)
 
 let rec translate_term ~g_vars ?l_vars ?(bound = Vars.empty) e =
@@ -82,6 +93,10 @@ let rec translate_term ~g_vars ?l_vars ?(bound = Vars.empty) e =
   (* A boolean program variable asserted as a proposition: [v = True]. *)
   | BoolVar x ->
       T.t_equ (T.t_var (resolve ~g_vars ?l_vars ~bound x)) T.t_bool_true
+  (* A boolean array element asserted as a proposition: [a[i] = True]. *)
+  | BGet (a, i) ->
+      let av = resolve ~g_vars ?l_vars ~bound a in
+      T.t_equ (Arith.aget_bool (T.t_var av) (f_a i)) T.t_bool_true
   | Not e -> T.t_not (f_t e)
   | And (e0, e1) -> T.t_and (f_t e0) (f_t e1)
   | Or (e0, e1) -> T.t_or (f_t e0) (f_t e1)

--- a/src/ast/logic.mli
+++ b/src/ast/logic.mli
@@ -31,6 +31,8 @@ type logic_expr =
   | Bool of bool
   | BoolVar of string
       (** a boolean program variable asserted as a proposition *)
+  | BGet of string * arith_expr
+      (** a boolean array element [a[i]] asserted as a proposition *)
   | Not of logic_expr
   | And of logic_expr * logic_expr
   | Or of logic_expr * logic_expr

--- a/src/ast/parse/logic.mly
+++ b/src/ast/parse/logic.mly
@@ -23,6 +23,14 @@
       { Forall (x, e) }
   | EXISTS x = VAR DOT e = logic_expr
       { Exists (x, e) }
+  (* Parenthesised proposition, e.g. [A && (forall j. P)]. A lone parenthesised
+     atom -- [(x)] or [(a[i])] -- is ambiguous between this and a parenthesised
+     arithmetic operand (as in [(x) = y]); Menhir reports two benign
+     reduce/reduce conflicts there and resolves them, by rule order, to the
+     proposition reading (which is what [(found)] wants). The only forms this
+     rejects are pointless ones like [(x) = y], written [x = y] instead. *)
+  | LPAREN e = logic_expr RPAREN
+      { e }
   | e0 = arith_expr EQ e1 = arith_expr
       { Eq (e0, e1) }
   | e0 = arith_expr NEQ e1 = arith_expr

--- a/src/ast/parse/logic.mly
+++ b/src/ast/parse/logic.mly
@@ -9,6 +9,8 @@
       { Bool (b) }
   | v = VAR
       { Ast.Logic.BoolVar (v) }
+  | a = VAR LBRACKET i = arith_expr RBRACKET
+      { Ast.Logic.BGet (a, i) }
   | NOT e = logic_expr
       { Not (e) }
   | e0 = logic_expr AND e1 = logic_expr

--- a/src/ast/program.ml
+++ b/src/ast/program.ml
@@ -26,7 +26,8 @@ type _ expr =
   | Mul : int expr * int expr -> int expr
   | Div : int expr * int expr -> int expr
   | Mod : int expr * int expr -> int expr
-  | Get : string * int expr -> int expr (* array element a[i] *)
+  | Get : string * int expr -> int expr (* integer array element a[i] *)
+  | BGet : string * int expr -> bool expr (* boolean array element a[i] *)
   | Len : string -> int expr (* array length len(a) *)
 [@@deriving sexp_of]
 
@@ -47,7 +48,7 @@ type cmd =
     (* invariant, optional variant (decreasing measure), guard, body *)
   | Print of int expr
   | ArrMake of string * int expr (* a := array(n) *)
-  | ArrAssgn of string * int expr * int expr (* a[i] := e *)
+  | ArrAssgn of string * int expr * anyexpr (* a[i] := e (integer or boolean) *)
   | Located of Loc.t * cmd
     (* a command annotated with its source location, used to point error
        messages at the construct whose obligation failed *)
@@ -91,12 +92,13 @@ exception TypeError of string
    or the integer comparison. A bare variable is boolean iff [is_bool] says so;
    the syntactic boolean forms are boolean regardless. [Typecheck] has validated
    that both operands agree, so testing the left one suffices. *)
-let rec is_bool_operand ~is_bool = function
+let rec is_bool_operand ~is_bool ~is_bool_array = function
   | UBool _ | UEq _ | UNeq _ | ULt _ | ULeq _ | UGt _ | UGeq _ | UAnd _ | UOr _
   | UNot _ ->
       true
   | UVar x -> is_bool x
-  | ULoc (_, e) -> is_bool_operand ~is_bool e
+  | UGet (a, _) -> is_bool_array a
+  | ULoc (_, e) -> is_bool_operand ~is_bool ~is_bool_array e
   | _ -> false
 
 let rec t_int_expr = function
@@ -111,18 +113,21 @@ let rec t_int_expr = function
   | ULen a -> Len a
   | e -> raise (TypeError (show_ut_expr e))
 
-and t_bool_expr ~is_bool e =
-  let recur = t_bool_expr ~is_bool in
+and t_bool_expr ~is_bool ~is_bool_array e =
+  let recur = t_bool_expr ~is_bool ~is_bool_array in
+  let bool_operand = is_bool_operand ~is_bool ~is_bool_array in
   match e with
   | UBool v -> Value (Bool v)
   (* A bare variable in boolean position is a boolean variable; [Typecheck] has
      already established that [v] is boolean-typed. *)
   | UVar v -> Value (BoolVar v)
+  (* [a[i]] in boolean position is an element of a boolean array. *)
+  | UGet (a, i) -> BGet (a, t_int_expr i)
   | UEq (a, b) ->
-      if is_bool_operand ~is_bool a then Beq (recur a, recur b)
+      if bool_operand a then Beq (recur a, recur b)
       else Eq (t_int_expr a, t_int_expr b)
   | UNeq (a, b) ->
-      if is_bool_operand ~is_bool a then Bneq (recur a, recur b)
+      if bool_operand a then Bneq (recur a, recur b)
       else Neq (t_int_expr a, t_int_expr b)
   | ULt (a, b) -> Lt (t_int_expr a, t_int_expr b)
   | ULeq (a, b) -> Leq (t_int_expr a, t_int_expr b)
@@ -141,29 +146,34 @@ let expr_to_cmd e = IntExpr (t_int_expr e)
 (* Elaborate an assignment right-hand side at its target's type: a boolean-typed
    variable ([is_bool x]) takes a boolean expression, any other an integer one.
    [Typecheck] guarantees the source expression matches. *)
-let t_rhs ~is_bool x e =
-  if is_bool x then BoolE (t_bool_expr ~is_bool e) else IntE (t_int_expr e)
+let t_rhs ~is_bool ~is_bool_array x e =
+  if is_bool x then BoolE (t_bool_expr ~is_bool ~is_bool_array e)
+  else IntE (t_int_expr e)
 
-let rec t_cmd ~is_bool ~proc_bool_params c =
-  let recur = t_cmd ~is_bool ~proc_bool_params in
+let rec t_cmd ~is_bool ~is_bool_array ~proc_bool_params c =
+  let recur = t_cmd ~is_bool ~is_bool_array ~proc_bool_params in
+  let bexpr = t_bool_expr ~is_bool ~is_bool_array in
   match c with
   | ULoc (loc, e) -> Located (loc, recur e)
   | USeq (c, c') -> Seq (recur c, recur c')
-  | UAssgn (s, e) -> Assgn (s, t_rhs ~is_bool s e)
-  | ULet (s, e) -> Let (s, t_rhs ~is_bool s e)
+  | UAssgn (s, e) -> Assgn (s, t_rhs ~is_bool ~is_bool_array s e)
+  | ULet (s, e) -> Let (s, t_rhs ~is_bool ~is_bool_array s e)
   | UProc (f, ps) ->
       (* Each actual is elaborated at its formal's type: a boolean parameter
          takes a boolean argument. [Typecheck] has matched the arity. *)
-      let arg is_b e =
-        if is_b then BoolE (t_bool_expr ~is_bool e) else IntE (t_int_expr e)
-      in
+      let arg is_b e = if is_b then BoolE (bexpr e) else IntE (t_int_expr e) in
       Proc (f, List.map2_exn (proc_bool_params f) ps ~f:arg)
-  | UIf (e, c, c') -> If (t_bool_expr ~is_bool e, recur c, recur c')
-  | UWhile (inv, variant, e, c) ->
-      While (inv, variant, t_bool_expr ~is_bool e, recur c)
+  | UIf (e, c, c') -> If (bexpr e, recur c, recur c')
+  | UWhile (inv, variant, e, c) -> While (inv, variant, bexpr e, recur c)
   | UPrint e -> Print (t_int_expr e)
   | UArrMake (a, n) -> ArrMake (a, t_int_expr n)
-  | UArrAssgn (a, i, e) -> ArrAssgn (a, t_int_expr i, t_int_expr e)
+  (* An element assignment carries a boolean value for a boolean array. *)
+  | UArrAssgn (a, i, e) ->
+      let v =
+        if is_bool_array a then BoolE (bexpr e) else IntE (t_int_expr e)
+      in
+      ArrAssgn (a, t_int_expr i, v)
   | v -> expr_to_cmd v
 
-let translate_cmd ~is_bool ~proc_bool_params = t_cmd ~is_bool ~proc_bool_params
+let translate_cmd ~is_bool ~is_bool_array ~proc_bool_params =
+  t_cmd ~is_bool ~is_bool_array ~proc_bool_params

--- a/src/ast/program.mli
+++ b/src/ast/program.mli
@@ -40,6 +40,7 @@ type _ expr =
   | Div : int expr * int expr -> int expr
   | Mod : int expr * int expr -> int expr
   | Get : string * int expr -> int expr
+  | BGet : string * int expr -> bool expr
   | Len : string -> int expr
 [@@deriving sexp_of]
 
@@ -61,7 +62,7 @@ type cmd =
   | While of Logic.expr * Logic.arith_expr option * bool expr * cmd
   | Print of int expr
   | ArrMake of string * int expr
-  | ArrAssgn of string * int expr * int expr
+  | ArrAssgn of string * int expr * anyexpr
   | Located of Loc.t * cmd
 [@@deriving sexp_of]
 
@@ -108,15 +109,17 @@ exception TypeError of string
 
 val translate_cmd :
   is_bool:(string -> bool) ->
+  is_bool_array:(string -> bool) ->
   proc_bool_params:(string -> bool list) ->
   ut_expr ->
   cmd
 (** Translate the untyped parser output into the typed {!cmd} AST. [is_bool]
-    reports whether a name is a boolean variable, so its occurrences and the
-    right-hand sides assigned to it elaborate at [bool] rather than [int];
-    [proc_bool_params f] gives, per formal of procedure [f], whether it is
-    boolean, so a call's actuals elaborate at their formals' types. Both come
-    from {!Typecheck}, which has already validated well-typedness.
+    reports whether a name is a boolean variable and [is_bool_array] whether it
+    is a boolean array, so occurrences and assigned right-hand sides elaborate
+    at [bool] rather than [int]; [proc_bool_params f] gives, per formal of
+    procedure [f], whether it is boolean, so a call's actuals elaborate at their
+    formals' types. All come from {!Typecheck}, which has already validated
+    well-typedness.
 
     @raise TypeError on malformed input (a checked program never triggers this).
 *)

--- a/src/ast/runtime.ml
+++ b/src/ast/runtime.ml
@@ -133,6 +133,8 @@ let rec exec_expr : type a. Runtime.t -> a expr -> a =
       let v1 = exec_expr r a in
       v1 mod exec_expr r b
   | Get (a, i) -> (Runtime.find_array r a).(exec_expr r i)
+  (* Boolean arrays share the integer array store, encoded 0/1 like scalars. *)
+  | BGet (a, i) -> (Runtime.find_array r a).(exec_expr r i) <> 0
   | Len a -> Array.length (Runtime.find_array r a)
   | Eq (a, b) ->
       let v1 = exec_expr r a in
@@ -226,7 +228,12 @@ and exec_cmd ?(fuel = ref max_int) r c : int * Runtime.t =
       (0, Runtime.add_global_array r a arr)
   | ArrAssgn (a, i, e) ->
       let idx = exec_expr r i in
-      let v = exec_expr r e in
+      (* A boolean value is stored 0/1, like a boolean scalar. *)
+      let v =
+        match e with
+        | IntE e -> exec_expr r e
+        | BoolE e -> if exec_expr r e then 1 else 0
+      in
       (* Mutate in place: [exec_cmd] threads the environment linearly (every
          caller discards its input once it holds the successor), so no live
          environment aliases this array. Same array object, same map -- O(1). *)

--- a/src/ast/triple.ml
+++ b/src/ast/triple.ml
@@ -27,13 +27,14 @@ type t = {
    the typed AST and everything downstream ([Hoare], [Runtime], [Compile]) work
    with plain parameter names. [is_bool] (also from {!Typecheck}) directs the
    elaboration of boolean variables. *)
-let translate ~is_bool ~proc_bool_params { p; f; variant; ws; ps; u; q } =
+let translate ~is_bool ~is_bool_array ~proc_bool_params
+    { p; f; variant; ws; ps; u; q } =
   {
     p;
     f;
     variant;
     ws;
     ps = List.map fst ps;
-    c = Program.translate_cmd ~is_bool ~proc_bool_params u;
+    c = Program.translate_cmd ~is_bool ~is_bool_array ~proc_bool_params u;
     q;
   }

--- a/src/ast/typecheck.ml
+++ b/src/ast/typecheck.ml
@@ -48,6 +48,7 @@ let rec arrays_arith (e : Logic.arith_expr) =
 let rec arrays_logic (e : Logic.logic_expr) =
   match e with
   | Logic.Bool _ | Logic.BoolVar _ -> SS.empty
+  | Logic.BGet (a, i) -> SS.add a (arrays_arith i)
   | Logic.Not e | Logic.Forall (_, e) | Logic.Exists (_, e) -> arrays_logic e
   | Logic.And (a, b) | Logic.Or (a, b) | Logic.Impl (a, b) ->
       SS.union (arrays_logic a) (arrays_logic b)
@@ -162,12 +163,24 @@ let rec classify_bool (e : Program.ut_expr) =
 let rec bools_logic (e : Logic.logic_expr) =
   match e with
   | Logic.BoolVar x -> SS.singleton x
-  | Logic.Bool _ | Logic.Eq _ | Logic.Neq _ | Logic.Lt _ | Logic.Leq _
-  | Logic.Gt _ | Logic.Geq _ ->
+  | Logic.Bool _ | Logic.BGet _ | Logic.Eq _ | Logic.Neq _ | Logic.Lt _
+  | Logic.Leq _ | Logic.Gt _ | Logic.Geq _ ->
       SS.empty
   | Logic.Not e | Logic.Forall (_, e) | Logic.Exists (_, e) -> bools_logic e
   | Logic.And (a, b) | Logic.Or (a, b) | Logic.Impl (a, b) ->
       SS.union (bools_logic a) (bools_logic b)
+
+(* Boolean arrays mentioned via an element proposition ([a[i]]) in an assertion. *)
+let rec bool_arrays_logic (e : Logic.logic_expr) =
+  match e with
+  | Logic.BGet (a, _) -> SS.singleton a
+  | Logic.BoolVar _ | Logic.Bool _ | Logic.Eq _ | Logic.Neq _ | Logic.Lt _
+  | Logic.Leq _ | Logic.Gt _ | Logic.Geq _ ->
+      SS.empty
+  | Logic.Not e | Logic.Forall (_, e) | Logic.Exists (_, e) ->
+      bool_arrays_logic e
+  | Logic.And (a, b) | Logic.Or (a, b) | Logic.Impl (a, b) ->
+      SS.union (bool_arrays_logic a) (bool_arrays_logic b)
 
 (* Copy edges [(v, x)] from each assignment [x := v] of a bare variable: if [v]
    is boolean then so is [x]. Saturating these (see [check]) infers the type of
@@ -204,9 +217,67 @@ let program_bools (program : Triple.ut_t list) =
            (SS.union (bools_logic t.p) (bools_logic t.q))))
     SS.empty program
 
+(* An array is boolean-element when a boolean context forces its elements: an
+   element assigned a syntactically-boolean expression ([a[i] := b < c]), or an
+   element [a[i]] used as a bare boolean (a guard or an operand of &&/||/!).
+   Mirrors [classify_bool] for scalars. *)
+let rec classify_bool_array (e : Program.ut_expr) =
+  let open Program in
+  let ( ++ ) = SS.union in
+  (* An element access occupying a position that demands a boolean. *)
+  let barr = function UGet (a, _) -> SS.singleton a | _ -> SS.empty in
+  match e with
+  | UArrAssgn (a, i, e) ->
+      let here = if is_syntactically_bool e then SS.singleton a else SS.empty in
+      here ++ classify_bool_array i ++ classify_bool_array e
+  | UAnd (a, b) | UOr (a, b) ->
+      barr a ++ barr b ++ classify_bool_array a ++ classify_bool_array b
+  | UNot a -> barr a ++ classify_bool_array a
+  | UIf (c, a, b) ->
+      barr c ++ classify_bool_array c ++ classify_bool_array a
+      ++ classify_bool_array b
+  | UWhile (_inv, _variant, c, body) ->
+      barr c ++ classify_bool_array c ++ classify_bool_array body
+  | USeq (a, b) -> classify_bool_array a ++ classify_bool_array b
+  | ULoc (_, e) | UPrint e | UAssgn (_, e) | ULet (_, e) ->
+      classify_bool_array e
+  | UArrMake (_, n) -> classify_bool_array n
+  | UProc (_, args) ->
+      List.fold_left (fun s a -> s ++ classify_bool_array a) SS.empty args
+  | UEq (a, b)
+  | UNeq (a, b)
+  | ULt (a, b)
+  | ULeq (a, b)
+  | UGt (a, b)
+  | UGeq (a, b)
+  | UPlus (a, b)
+  | USub (a, b)
+  | UMul (a, b)
+  | UDiv (a, b)
+  | UMod (a, b) ->
+      classify_bool_array a ++ classify_bool_array b
+  | UGet (_, i) -> classify_bool_array i
+  | UInt _ | UBool _ | UVar _ | ULen _ -> SS.empty
+
+let program_bool_arrays (program : Triple.ut_t list) =
+  List.fold_left
+    (fun s (t : Triple.ut_t) ->
+      SS.union s
+        (SS.union (classify_bool_array t.u)
+           (SS.union (bool_arrays_logic t.p) (bool_arrays_logic t.q))))
+    SS.empty program
+
 (* ===== Expression typing ===== *)
 
-type env = { arrays : SS.t; bools : SS.t; procs : (string * Ty.t list) list }
+type env = {
+  arrays : SS.t;
+  bools : SS.t;
+  bool_arrays : SS.t;
+  procs : (string * Ty.t list) list;
+}
+
+(* The element type of an array: boolean if inferred so, otherwise integer. *)
+let element_type env a = if SS.mem a env.bool_arrays then Ty.Bool else Ty.Int
 
 let require_array env loc a =
   if not (SS.mem a env.arrays) then
@@ -228,7 +299,7 @@ let rec synth env loc (e : Program.ut_expr) : Ty.t =
   | UGet (a, i) ->
       require_array env loc a;
       expect env loc Ty.Int i;
-      Ty.Int
+      element_type env a
   | ULen a ->
       require_array env loc a;
       Ty.Int
@@ -288,7 +359,7 @@ let rec synth_arith env bound (e : Logic.arith_expr) : Ty.t =
   | Logic.Get (a, i) ->
       require_array env None a;
       expect_arith env bound Ty.Int i;
-      Ty.Int
+      element_type env a
   | Logic.Len a ->
       require_array env None a;
       Ty.Int
@@ -309,6 +380,12 @@ let rec check_logic env bound (e : Logic.logic_expr) : unit =
         fail None "array '%s' cannot be used as a proposition" x
       else if not (SS.mem x env.bools) then
         fail None "'%s' is not a boolean but is used as a proposition" x
+  | Logic.BGet (a, i) ->
+      require_array env None a;
+      if not (SS.mem a env.bool_arrays) then
+        fail None
+          "array '%s' is not boolean, so its element cannot be a proposition" a;
+      expect_arith env bound Ty.Int i
   | Logic.Not e -> check_logic env bound e
   | Logic.And (a, b) | Logic.Or (a, b) | Logic.Impl (a, b) ->
       check_logic env bound a;
@@ -373,7 +450,8 @@ let rec check_cmd env loc (e : Program.ut_expr) : unit =
   | UArrAssgn (a, i, e) ->
       require_array env loc a;
       expect env loc Ty.Int i;
-      expect env loc Ty.Int e
+      (* The value matches the array's element type. *)
+      expect env loc (element_type env a) e
   (* A bare expression as a statement (its value is discarded, e.g. a program's
      final result). It must be a well-typed integer expression -- the same
      restriction [Program.expr_to_cmd] elaborates against. *)
@@ -402,12 +480,14 @@ let check_params ~arrays ~bools (ps : (string * Ty.t option) list) =
 
 type checked = {
   bool_vars : string list;  (** names of the program's boolean variables *)
+  bool_arrays : string list;  (** names of the program's boolean arrays *)
   proc_bool_params : (string * bool list) list;
       (** per procedure, whether each formal parameter is boolean *)
 }
 
 let check (program : Triple.ut_t list) : checked =
   let arrays = program_arrays program in
+  let bool_arrays = program_bool_arrays program in
   (* Boolean names: inferred from bodies and assertions, plus any parameter
      annotated [: bool]. *)
   let annotated_bools =
@@ -444,7 +524,7 @@ let check (program : Triple.ut_t list) : checked =
           rev_procs
     | [] -> []
   in
-  let env = { arrays; bools; procs } in
+  let env = { arrays; bools; bool_arrays; procs } in
   List.iter
     (fun (t : Triple.ut_t) ->
       check_params ~arrays ~bools t.ps;
@@ -455,6 +535,7 @@ let check (program : Triple.ut_t list) : checked =
     program;
   {
     bool_vars = SS.elements bools;
+    bool_arrays = SS.elements bool_arrays;
     proc_bool_params =
       List.map (fun (f, tys) -> (f, List.map (Ty.equal Ty.Bool) tys)) procs;
   }

--- a/src/ast/typecheck.mli
+++ b/src/ast/typecheck.mli
@@ -15,6 +15,7 @@ exception Type_error of Loc.t option * string
 
 type checked = {
   bool_vars : string list;  (** names of the program's boolean variables *)
+  bool_arrays : string list;  (** names of the program's boolean arrays *)
   proc_bool_params : (string * bool list) list;
       (** per procedure, whether each formal parameter is boolean *)
 }

--- a/src/ast/var_collection.ml
+++ b/src/ast/var_collection.ml
@@ -30,6 +30,7 @@ let collect_logic e =
   let rec collect_logic_expr = function
     | Bool _ -> Str_set.empty
     | BoolVar x -> Str_set.singleton x
+    | BGet (a, i) -> Str_set.add a (collect_arith_expr i)
     | Not e -> collect_logic_expr e
     | And (e, e') | Or (e, e') | Impl (e, e') ->
         Str_set.union (collect_logic_expr e) (collect_logic_expr e')
@@ -68,7 +69,7 @@ let collect_program c =
     | And (e, e') | Or (e, e') | Beq (e, e') | Bneq (e, e') ->
         Str_set.union (collect_expr e) (collect_expr e')
     | Not e -> collect_expr e
-    | Get (a, e) -> Str_set.add a (collect_expr e)
+    | Get (a, e) | BGet (a, e) -> Str_set.add a (collect_expr e)
     | Len a -> Str_set.singleton a
   in
   let collect_any = function
@@ -94,7 +95,7 @@ let collect_program c =
     | Print e -> collect_expr e
     | ArrMake (a, n) -> Str_set.add a (collect_expr n)
     | ArrAssgn (a, i, e) ->
-        Str_set.add a (Str_set.union (collect_expr i) (collect_expr e))
+        Str_set.add a (Str_set.union (collect_expr i) (collect_any e))
   in
   collect_cmd c
 
@@ -119,6 +120,7 @@ let arrays_logic e =
   let arith = arrays_arith in
   let rec logic = function
     | Bool _ | BoolVar _ -> Str_set.empty
+    | BGet (a, i) -> Str_set.add a (arith i)
     | Not e | Forall (_, e) | Exists (_, e) -> logic e
     | And (a, b) | Or (a, b) | Impl (a, b) -> Str_set.union (logic a) (logic b)
     | Eq (a, b) | Neq (a, b) | Lt (a, b) | Leq (a, b) | Gt (a, b) | Geq (a, b)
@@ -131,7 +133,7 @@ let arrays_program c =
   let open Program in
   let rec expr : type a. a expr -> Str_set.t = function
     | Value _ -> Str_set.empty
-    | Get (a, e) -> Str_set.add a (expr e)
+    | Get (a, e) | BGet (a, e) -> Str_set.add a (expr e)
     | Len a -> Str_set.singleton a
     | Plus (a, b)
     | Sub (a, b)
@@ -163,7 +165,7 @@ let arrays_program c =
     | Proc (_, ps) ->
         List.fold_left (fun s e -> Str_set.union s (any e)) Str_set.empty ps
     | ArrMake (a, n) -> Str_set.add a (expr n)
-    | ArrAssgn (a, i, e) -> Str_set.add a (Str_set.union (expr i) (expr e))
+    | ArrAssgn (a, i, e) -> Str_set.add a (Str_set.union (expr i) (any e))
   in
   cmd c
 
@@ -180,7 +182,7 @@ let bools_program c =
   in
   let rec expr : type a. a expr -> Str_set.t = function
     | Value v -> value v
-    | Get (_, e) -> expr e
+    | Get (_, e) | BGet (_, e) -> expr e
     | Len _ -> Str_set.empty
     | Plus (a, b)
     | Sub (a, b)
@@ -210,7 +212,50 @@ let bools_program c =
     | Proc (_, ps) ->
         List.fold_left (fun s e -> Str_set.union s (any e)) Str_set.empty ps
     | ArrMake (_, n) -> expr n
-    | ArrAssgn (_, i, e) -> Str_set.union (expr i) (expr e)
+    | ArrAssgn (_, i, e) -> Str_set.union (expr i) (any e)
+  in
+  cmd c
+
+(* Names used as boolean arrays: an array read as a [BGet], or the target of an
+   element assignment whose value is boolean ([BoolE]). A boolean-array name is
+   given a [map int bool] symbol by [str_set_to_vars]. *)
+let bool_arrays_program c =
+  let open Program in
+  let rec expr : type a. a expr -> Str_set.t = function
+    | Value _ -> Str_set.empty
+    | BGet (a, e) -> Str_set.add a (expr e)
+    | Get (_, e) -> expr e
+    | Len _ -> Str_set.empty
+    | Plus (a, b)
+    | Sub (a, b)
+    | Mul (a, b)
+    | Div (a, b)
+    | Mod (a, b)
+    | Eq (a, b)
+    | Neq (a, b)
+    | Lt (a, b)
+    | Leq (a, b)
+    | Gt (a, b)
+    | Geq (a, b) ->
+        Str_set.union (expr a) (expr b)
+    | And (a, b) | Or (a, b) | Beq (a, b) | Bneq (a, b) ->
+        Str_set.union (expr a) (expr b)
+    | Not a -> expr a
+  in
+  let any = function IntE e -> expr e | BoolE e -> expr e in
+  let rec cmd = function
+    | Located (_, c) -> cmd c
+    | IntExpr e | Print e -> expr e
+    | Assgn (_, e) | Let (_, e) -> any e
+    | Seq (a, b) -> Str_set.union (cmd a) (cmd b)
+    | If (b, c, c') -> Str_set.union (expr b) (Str_set.union (cmd c) (cmd c'))
+    | While (_inv, _variant, b, c) -> Str_set.union (expr b) (cmd c)
+    | Proc (_, ps) ->
+        List.fold_left (fun s e -> Str_set.union s (any e)) Str_set.empty ps
+    | ArrMake (_, n) -> expr n
+    | ArrAssgn (a, i, BoolE e) ->
+        Str_set.add a (Str_set.union (expr i) (expr e))
+    | ArrAssgn (_, i, IntE e) -> Str_set.union (expr i) (expr e)
   in
   cmd c
 
@@ -239,7 +284,20 @@ let bools_logic e =
   let open Logic in
   let rec go = function
     | BoolVar x -> Str_set.singleton x
-    | Bool _ | Eq _ | Neq _ | Lt _ | Leq _ | Gt _ | Geq _ -> Str_set.empty
+    | Bool _ | BGet _ | Eq _ | Neq _ | Lt _ | Leq _ | Gt _ | Geq _ ->
+        Str_set.empty
+    | Not e | Forall (_, e) | Exists (_, e) -> go e
+    | And (a, b) | Or (a, b) | Impl (a, b) -> Str_set.union (go a) (go b)
+  in
+  go e
+
+(* Boolean arrays an assertion mentions via an element proposition ([BGet]). *)
+let bool_arrays_logic e =
+  let open Logic in
+  let rec go = function
+    | BGet (a, _) -> Str_set.singleton a
+    | BoolVar _ | Bool _ | Eq _ | Neq _ | Lt _ | Leq _ | Gt _ | Geq _ ->
+        Str_set.empty
     | Not e | Forall (_, e) | Exists (_, e) -> go e
     | And (a, b) | Or (a, b) | Impl (a, b) -> Str_set.union (go a) (go b)
   in
@@ -253,6 +311,14 @@ let all_bools (program : Triple.t list) =
            (Str_set.union (bools_logic t.p) (bools_logic t.q))))
     Str_set.empty program
 
+let all_bool_arrays (program : Triple.t list) =
+  List.fold_left
+    (fun s (t : Triple.t) ->
+      Str_set.union s
+        (Str_set.union (bool_arrays_program t.c)
+           (Str_set.union (bool_arrays_logic t.p) (bool_arrays_logic t.q))))
+    Str_set.empty program
+
 let collect_procedure globals (t : Triple.t) =
   let p_vars = collect_logic t.p in
   let q_vars = collect_logic t.q in
@@ -262,13 +328,17 @@ let collect_procedure globals (t : Triple.t) =
   (* If global variables occur in the procedure, don't add them as local variables *)
   Str_set.fold (fun global vars -> Str_set.remove global vars) globals vars
 
-let str_set_to_vars ~arrays ~bools vars =
+let str_set_to_vars ~arrays ~bools ~bool_arrays vars =
   let f x vs =
     if Str_set.mem x arrays then
-      (* An array contributes two symbols: its [map int int] element store and a
-         companion integer length under [Vars.len_key]. *)
-      Vars.add x
-        (Vars.create_fresh_array x)
+      (* An array contributes two symbols: its element store ([map int int] or,
+         for a boolean array, [map int bool]) and a companion integer length
+         under [Vars.len_key]. *)
+      let store =
+        if Str_set.mem x bool_arrays then Vars.create_fresh_bool_array x
+        else Vars.create_fresh_array x
+      in
+      Vars.add x store
         (Vars.add (Vars.len_key x) (Vars.create_fresh (Vars.len_key x)) vs)
     else if Str_set.mem x bools then Vars.add x (Vars.create_fresh_bool x) vs
     else Vars.add x (Vars.create_fresh x) vs
@@ -279,16 +349,14 @@ let collect (program : Triple.t list) =
   let procedures, main = split_last program in
   let arrays = all_arrays program in
   let bools = all_bools program in
+  let bool_arrays = all_bool_arrays program in
+  let to_vars = str_set_to_vars ~arrays ~bools ~bool_arrays in
   let globals =
     Str_set.union (collect_procedure Str_set.empty main) (all_writes program)
   in
   let procedures =
     List.map
-      (fun proc ->
-        let vars =
-          str_set_to_vars ~arrays ~bools (collect_procedure globals proc)
-        in
-        (proc, vars))
+      (fun proc -> (proc, to_vars (collect_procedure globals proc)))
       procedures
   in
-  procedures @ [ (main, str_set_to_vars ~arrays ~bools globals) ]
+  procedures @ [ (main, to_vars globals) ]

--- a/src/ast/vars.ml
+++ b/src/ast/vars.ml
@@ -23,6 +23,11 @@ let create_fresh_bool x =
 let create_fresh_array x =
   Why3.Term.create_vsymbol (Why3.Ident.id_fresh x) (Lazy.force Arith.ty_int_map)
 
+(* A boolean-array variable ([map int bool]). *)
+let create_fresh_bool_array x =
+  Why3.Term.create_vsymbol (Why3.Ident.id_fresh x)
+    (Lazy.force Arith.ty_int_bool_map)
+
 (* A fresh variable of the *same type* as [vs]. Havoc'ing a variable must
    introduce a replacement of matching type, so an array (map) havocs to a fresh
    map, not a fresh integer. *)

--- a/src/ast/vars.mli
+++ b/src/ast/vars.mli
@@ -45,6 +45,9 @@ val create_fresh_bool : string -> Why3.Term.vsymbol
 val create_fresh_array : string -> Why3.Term.vsymbol
 (** A fresh array-valued ([map int int]) variable. *)
 
+val create_fresh_bool_array : string -> Why3.Term.vsymbol
+(** A fresh boolean-array ([map int bool]) variable. *)
+
 val fresh_like : T.vsymbol -> Why3.Term.vsymbol
 (** A fresh variable of the same type as the argument, for havoc'ing a variable
     without assuming it is an integer. *)

--- a/src/compile.ml
+++ b/src/compile.ml
@@ -126,7 +126,7 @@ let rec assigned = function
 (* Array globals to declare = every name used as an array anywhere in the
    program bodies (created, element-written, indexed, or measured). *)
 let rec arrays_expr : type a. a expr -> Str_set.t = function
-  | Get (a, i) -> Str_set.add a (arrays_expr i)
+  | Get (a, i) | BGet (a, i) -> Str_set.add a (arrays_expr i)
   | Len a -> Str_set.singleton a
   | Value _ -> Str_set.empty
   | Plus (a, b)
@@ -155,7 +155,8 @@ let rec arrays = function
   | Assgn (_, BoolE e) | Let (_, BoolE e) -> arrays_expr e
   | ArrMake (a, n) -> Str_set.add a (arrays_expr n)
   | ArrAssgn (a, i, e) ->
-      Str_set.add a (Str_set.union (arrays_expr i) (arrays_expr e))
+      let any = function IntE e -> arrays_expr e | BoolE e -> arrays_expr e in
+      Str_set.add a (Str_set.union (arrays_expr i) (any e))
   | Proc (_, ps) ->
       let any = function IntE e -> arrays_expr e | BoolE e -> arrays_expr e in
       List.fold_left (fun s e -> Str_set.union s (any e)) Str_set.empty ps
@@ -213,6 +214,12 @@ let emit_bool ~ops ~locals (e : bool expr) : string =
     match e with
     | Value (Bool b) -> string_of_bool b
     | Value (BoolVar x) -> emit_read ~locals x
+    (* A boolean array is a backend-int array encoded 0/1: read the element and
+       compare it to zero. *)
+    | BGet (a, i) ->
+        Printf.sprintf "(not (%s (!%s).(%s) %s))" ops.eq (gref a)
+          (ops.idx (emit_int ~ops ~locals i))
+          ops.zero
     | Eq (a, b) -> cmp ops.eq a b
     | Neq (a, b) -> Printf.sprintf "(not %s)" (cmp ops.eq a b)
     | Lt (a, b) -> cmp ops.lt a b
@@ -264,9 +271,17 @@ let rec emit_cmd ~ops ~locals c : string =
         (ops.idx (emit_int ~ops ~locals n))
         ops.zero ops.zero
   | ArrAssgn (a, i, e) ->
-      (* a[i] := e; command value is the assigned element. *)
-      Printf.sprintf "(let v = %s in (!%s).(%s) <- v; v)"
-        (emit_int ~ops ~locals e) (gref a)
+      (* a[i] := e; command value is the assigned element. A boolean value is
+         stored 0/1 (like a boolean scalar), keeping the array a backend-int
+         array. *)
+      let v =
+        match e with
+        | IntE e -> emit_int ~ops ~locals e
+        | BoolE e ->
+            Printf.sprintf "(if %s then %s else %s)" (emit_bool ~ops ~locals e)
+              (ops.lit 1) ops.zero
+      in
+      Printf.sprintf "(let v = %s in (!%s).(%s) <- v; v)" v (gref a)
         (ops.idx (emit_int ~ops ~locals i))
   | IntExpr e -> emit_int ~ops ~locals e
   | If (b, c, c') ->

--- a/src/hoare.ml
+++ b/src/hoare.ml
@@ -153,6 +153,9 @@ let rec expr_to_term : type a.
   | Div (e, e') -> div (f e) (f e')
   | Mod (e, e') -> modulo (f e) (f e')
   | Get (a, i) -> aget (T.t_var (resolve a)) (f i)
+  (* A boolean array element is a [bool] term; coerce it to a formula with
+     [= True], as for a boolean variable. *)
+  | BGet (a, i) -> T.t_equ (aget_bool (T.t_var (resolve a)) (f i)) T.t_bool_true
   | Len a -> T.t_var (resolve (Vars.len_key a))
 
 (* [0 <= i < len(a)]: the well-definedness obligation for accessing [a\[i\]],
@@ -200,6 +203,8 @@ let rec safe : type a.
          was itself proven [safe] on write; only the index expression can
          overflow. [Len] is a tracked variable, in range by assumption. *)
       self i
+  (* A boolean element carries no arithmetic; only its index can overflow. *)
+  | BGet (_, i) -> self i
   | Len _ -> T.t_true
   | Eq (a, b) | Neq (a, b) | Lt (a, b) | Leq (a, b) | Gt (a, b) | Geq (a, b) ->
       T.t_and_simp (self a) (self b)
@@ -247,7 +252,7 @@ let rec defined : type a.
           (Arith.neq (expr_to_term ~g_vars ?l_vars b) (T.t_nat_const 0))
       in
       T.t_and_simp (T.t_and_simp (self a) (self b)) nonzero
-  | Get (a, i) ->
+  | Get (a, i) | BGet (a, i) ->
       let bounds =
         index_in_bounds ~g_vars ?l_vars ?loc a (expr_to_term ~g_vars ?l_vars i)
       in
@@ -430,15 +435,19 @@ module Wlp = struct
         in
         T.t_and_simp safe assign
     | ArrMake (a, n) ->
-        (* a := array(n): length := n, elements := all zeros.
+        (* a := array(n): length := n, elements := the all-zeros ([False] for a
+           boolean array) map.
            safe(n) /\ 0 <= n /\ q[ a <- const 0 ][ len(a) <- n ] *)
         let n_t = expr_to_term ~g_vars ~l_vars n in
         let a_v = Vars.find_fallback a l_vars g_vars in
         let len_v = Vars.find_fallback (Vars.len_key a) l_vars g_vars in
+        let default =
+          if Ty.ty_equal a_v.T.vs_ty (Lazy.force Arith.ty_int_bool_map) then
+            Lazy.force Arith.bfalse
+          else Lazy.force Arith.azero
+        in
         let q_sub =
-          T.t_subst
-            (T.Mvs.of_list [ (a_v, Lazy.force Arith.azero); (len_v, n_t) ])
-            q
+          T.t_subst (T.Mvs.of_list [ (a_v, default); (len_v, n_t) ]) q
         in
         let nonneg =
           tag ?loc Array_length_nonneg (Arith.leq (T.t_nat_const 0) n_t)
@@ -446,14 +455,27 @@ module Wlp = struct
         T.t_and_simp (safe_e n) (T.t_and_simp nonneg q_sub)
     | ArrAssgn (a, i, e) ->
         (* a[i] := e: safe(i) /\ safe(e) /\ 0 <= i < len(a)
-           /\ q[ a <- set a i e ] *)
+           /\ q[ a <- set a i e ]. A boolean value is coerced to a [bool] term
+           (as for a boolean assignment) and stored with the boolean [set]. *)
         let i_t = expr_to_term ~g_vars ~l_vars i in
-        let e_t = expr_to_term ~g_vars ~l_vars e in
         let a_v = Vars.find_fallback a l_vars g_vars in
-        let q_sub = T.t_subst_single a_v (Arith.aset (T.t_var a_v) i_t e_t) q in
+        let updated, safe_v =
+          match e with
+          | IntE e ->
+              ( Arith.aset (T.t_var a_v) i_t (expr_to_term ~g_vars ~l_vars e),
+                safe_e e )
+          | BoolE e ->
+              let v =
+                T.t_if
+                  (expr_to_term ~g_vars ~l_vars e)
+                  T.t_bool_true T.t_bool_false
+              in
+              (Arith.aset_bool (T.t_var a_v) i_t v, safe_e e)
+        in
+        let q_sub = T.t_subst_single a_v updated q in
         let bounds = index_in_bounds ~g_vars ~l_vars ?loc a i_t in
         T.t_and_simp
-          (T.t_and_simp (safe_e i) (safe_e e))
+          (T.t_and_simp (safe_e i) safe_v)
           (T.t_and_simp bounds q_sub)
     | Proc (f, ps) ->
         (* safe(e_i) for each actual argument (evaluated in the caller's scope)

--- a/src/main.ml
+++ b/src/main.ml
@@ -14,12 +14,15 @@ let get_ast path =
   In_channel.close file;
   (* Reject ill-typed programs up front with a located diagnostic, and learn
      which variables are boolean so elaboration can type their occurrences. *)
-  let { Typecheck.bool_vars; proc_bool_params } = Typecheck.check ut_ast in
+  let { Typecheck.bool_vars; bool_arrays; proc_bool_params } =
+    Typecheck.check ut_ast
+  in
   let is_bool x = List.mem x bool_vars in
+  let is_bool_array x = List.mem x bool_arrays in
   let proc_bool_params f =
     match List.assoc_opt f proc_bool_params with Some bs -> bs | None -> []
   in
-  List.map (Triple.translate ~is_bool ~proc_bool_params) ut_ast
+  List.map (Triple.translate ~is_bool ~is_bool_array ~proc_bool_params) ut_ast
   |> Var_collection.collect
 
 let verify = Hoare.verify

--- a/test/compile.ml
+++ b/test/compile.ml
@@ -96,6 +96,23 @@ let%test_unit "Compile.emit - boolean scalar is a bool ref" =
   List.iter [ "let g_b = ref false"; "g_b :=" ] ~f:(fun substring ->
       [%test_pred: string] (contains ~substring) out)
 
+let%test_unit "Compile.emit - boolean array element encodes 0/1" =
+  (* a := array(2); a[0] := true; if a[0] then 1 else 0 end -- a boolean array is
+     a backend-int array: the element is stored 1 and read by comparing to 0. *)
+  let body =
+    Seq
+      ( ArrMake ("a", Value (Int 2)),
+        Seq
+          ( ArrAssgn ("a", Value (Int 0), BoolE (Value (Bool true))),
+            If
+              ( BGet ("a", Value (Int 0)),
+                IntExpr (Value (Int 1)),
+                IntExpr (Value (Int 0)) ) ) )
+  in
+  let out = emit_main body in
+  List.iter [ "Array.make"; "Z.equal"; "if true" ] ~f:(fun substring ->
+      [%test_pred: string] (contains ~substring) out)
+
 let%test_unit "Compile.emit - while emits a Zarith-guarded loop" =
   (* while i < 10 do invariant { true } i := i + 1 end *)
   let body =
@@ -155,7 +172,7 @@ let%test_unit "Compile.emit - arrays: array ref, make, and indexed get/set" =
     Seq
       ( ArrMake ("a", Value (Int 3)),
         Seq
-          ( ArrAssgn ("a", Value (Int 1), Value (Int 5)),
+          ( ArrAssgn ("a", Value (Int 1), IntE (Value (Int 5))),
             IntExpr (Plus (Len "a", Get ("a", Value (Int 1)))) ) )
   in
   let out = emit_main body in

--- a/test/dune
+++ b/test/dune
@@ -90,6 +90,7 @@
    verify_true_bool_array.cav
    verify_true_bool_array_read.cav
    type_error_bool_array_arith.cav
+   verify_true_paren_quantifier.cav
    type_error_bool_arith.cav
    type_error_var_guard.cav
    verify_false_writes_undeclared.cav

--- a/test/dune
+++ b/test/dune
@@ -87,6 +87,9 @@
    verify_true_bool_param.cav
    verify_true_bool_copy.cav
    type_error_bool_in_assertion.cav
+   verify_true_bool_array.cav
+   verify_true_bool_array_read.cav
+   type_error_bool_array_arith.cav
    type_error_bool_arith.cav
    type_error_var_guard.cav
    verify_false_writes_undeclared.cav

--- a/test/fuzz/fuzz.ml
+++ b/test/fuzz/fuzz.ml
@@ -437,7 +437,8 @@ let rec expr_to_cav : type a. a Program.expr -> string =
       Printf.sprintf "(%s = %s)" (expr_to_cav a) (expr_to_cav b)
   | Program.Bneq (a, b) ->
       Printf.sprintf "(%s != %s)" (expr_to_cav a) (expr_to_cav b)
-  | Program.Get (a, i) -> Printf.sprintf "%s[%s]" a (expr_to_cav i)
+  | Program.Get (a, i) | Program.BGet (a, i) ->
+      Printf.sprintf "%s[%s]" a (expr_to_cav i)
   | Program.Len a -> Printf.sprintf "len(%s)" a
 
 let rec arith_to_cav = function
@@ -464,6 +465,7 @@ let rec arith_to_cav = function
 let rec logic_to_cav = function
   | Logic.Bool b -> string_of_bool b
   | Logic.BoolVar x -> x
+  | Logic.BGet (a, i) -> Printf.sprintf "%s[%s]" a (arith_to_cav i)
   | Logic.Not e -> Printf.sprintf "!%s" (logic_to_cav e)
   | Logic.And (a, b) ->
       Printf.sprintf "%s && %s" (logic_to_cav a) (logic_to_cav b)
@@ -515,7 +517,7 @@ let rec cmd_to_cav c =
   | Program.Print e -> Printf.sprintf "print %s" (expr_to_cav e)
   | Program.ArrMake (a, n) -> Printf.sprintf "%s := array(%s)" a (expr_to_cav n)
   | Program.ArrAssgn (a, i, e) ->
-      Printf.sprintf "%s[%s] := %s" a (expr_to_cav i) (expr_to_cav e)
+      Printf.sprintf "%s[%s] := %s" a (expr_to_cav i) (any_to_cav e)
 
 let proc_to_cav (t : Triple.t) =
   Printf.sprintf

--- a/test/integration.ml
+++ b/test/integration.ml
@@ -529,6 +529,11 @@ let%test_unit "Main.get_ast type error boolean in assertion" =
   check_type_error ~substring:"in an assertion"
     "type_error_bool_in_assertion.cav"
 
+(* A boolean array element used in arithmetic. *)
+let%test_unit "Main.get_ast type error boolean array in arithmetic" =
+  check_type_error ~substring:"expected int but got bool"
+    "type_error_bool_array_arith.cav"
+
 (* Optional int parameter annotations are accepted and the program verifies. *)
 let%test_unit "Main.verify true annotated procedure" =
   check_verify "verify_true_annotated_proc.cav" Valid
@@ -567,6 +572,17 @@ let%test_unit "Main.verify true boolean parameter" =
 (* A variable copied from a boolean is inferred boolean ([same := pos]). *)
 let%test_unit "Main.verify true boolean copy" =
   check_verify "verify_true_bool_copy.cav" Valid
+
+(* A boolean array, with a quantified invariant/postcondition over its elements. *)
+let%test_unit "Main.verify true boolean array" =
+  check_verify "verify_true_bool_array.cav" Valid
+
+let%test_unit "Main.verify true boolean array read" =
+  check_verify "verify_true_bool_array_read.cav" Valid
+
+(* Its element read as a guard runs to a concrete result (a[1] is true). *)
+let%test_unit "Main.exec boolean array" =
+  [%test_result: int] (Main.exec "verify_true_bool_array_read.cav") ~expect:1
 
 (* The same boolean-scalar program runs to a concrete result (x = 5 >= 0, so the
    [else] branch gives y = x = 5). *)

--- a/test/integration.ml
+++ b/test/integration.ml
@@ -584,6 +584,10 @@ let%test_unit "Main.verify true boolean array read" =
 let%test_unit "Main.exec boolean array" =
   [%test_result: int] (Main.exec "verify_true_bool_array_read.cav") ~expect:1
 
+(* A parenthesised quantifier grouped inside an assertion. *)
+let%test_unit "Main.verify true parenthesised quantifier" =
+  check_verify "verify_true_paren_quantifier.cav" Valid
+
 (* The same boolean-scalar program runs to a concrete result (x = 5 >= 0, so the
    [else] branch gives y = x = 5). *)
 let%test_unit "Main.exec boolean scalar" =

--- a/test/program.ml
+++ b/test/program.ml
@@ -61,7 +61,11 @@ let%test_unit "Ast.Program.type_expr" =
         UIf (UEq (UInt 1, UInt 2), UInt 5, UMul (UVar "x", UInt 5)) )
   in
   let result =
-    translate_cmd ~is_bool:(fun _ -> false) ~proc_bool_params:(fun _ -> []) ut
+    translate_cmd
+      ~is_bool:(fun _ -> false)
+      ~is_bool_array:(fun _ -> false)
+      ~proc_bool_params:(fun _ -> [])
+      ut
   in
   test_ast_eq ~expected result
 
@@ -234,6 +238,7 @@ let%test_unit "Ast.Runtime.exec - function" =
         (* [f] takes one integer parameter. *)
         Triple.translate
           ~is_bool:(fun _ -> false)
+          ~is_bool_array:(fun _ -> false)
           ~proc_bool_params:(fun name ->
             if String.equal name "f" then [ false ] else [])
           ut

--- a/test/type_error_bool_array_arith.cav
+++ b/test/type_error_bool_array_arith.cav
@@ -1,0 +1,7 @@
+// a is a boolean array (a[0] := true), so using its element in arithmetic is a
+// type error.
+{ true }
+a := array(3);
+a[0] := true;
+x := a[0] + 1
+{ true }

--- a/test/verify_true_bool_array.cav
+++ b/test/verify_true_bool_array.cav
@@ -1,0 +1,12 @@
+// A boolean array: fill it with true and prove, via a quantified invariant and
+// postcondition over boolean elements, that every element is true.
+{ n >= 0 }
+a := array(n);
+i := 0;
+while i < len(a) do
+  invariant { 0 <= i && i <= len(a) && forall j . 0 <= j && j < i -> a[j] }
+  variant { len(a) - i }
+  a[i] := true;
+  i := i + 1
+end
+{ forall j . 0 <= j && j < len(a) -> a[j] }

--- a/test/verify_true_bool_array_read.cav
+++ b/test/verify_true_bool_array_read.cav
@@ -1,0 +1,12 @@
+// A boolean array element read as a guard: a[1] was set to true, so the first
+// branch is taken. Runnable and verifiable. (a[0] is the default, false.)
+{ true }
+a := array(3);
+a[1] := true;
+if a[1] then
+  x := 1
+else
+  x := 2
+end;
+x
+{ x = 1 }

--- a/test/verify_true_paren_quantifier.cav
+++ b/test/verify_true_paren_quantifier.cav
@@ -1,0 +1,11 @@
+// A parenthesised quantifier grouped inside an && chain in the invariant.
+{ n >= 0 }
+a := array(n);
+i := 0;
+while i < len(a) do
+  invariant { 0 <= i && i <= len(a) && (forall j . 0 <= j && j < i -> a[j] = 0) }
+  variant { len(a) - i }
+  a[i] := 0;
+  i := i + 1
+end
+{ forall j . 0 <= j && j < len(a) -> a[j] = 0 }


### PR DESCRIPTION
Arrays could only hold integers — the element type was hardwired to `int` across the AST, verifier, interpreter, and compiler. This adds boolean arrays, completing the last remaining boolean axis:

```
seen := array(n);
seen[i] := true;
if seen[j] then ... end
{ forall j . 0 <= j && j < len(seen) -> seen[j] }   // a boolean element as a proposition
```

## How it works

- **Inference.** An array is boolean-element when a boolean context forces it — `a[i]` assigned a boolean, read as a guard/connective operand, or asserted as a proposition. `Typecheck` classifies boolean arrays (parallel to boolean scalars), checks element types, and returns the classification.
- **Elaboration.** An `is_bool_array` predicate is threaded through translation so `a[i]` becomes `Get` (integer) or the new `BGet` (boolean), and an element assignment carries an `int` or `bool` value (`ArrAssgn of string * int expr * anyexpr`).
- **Verifier.** A boolean array is Why3's `map int bool` (new `aget_bool`/`aset_bool` and an all-`False` default from `map.Const`); an element coerces to a formula with `= True`, as for a boolean variable, and `ArrMake` picks the zero or `False` default from the array's sort.
- **Assertions.** A boolean element is a new `Logic.BGet` proposition — an LR(1) conflict-free grammar addition (a bare variable vs `a[i]` resolves by the following token) — and integer `Get` translation is sort-aware, so `a[i] = b[j]` over booleans uses `t_equ`.
- **Backends.** The interpreter and compiler keep boolean arrays as backend-int arrays encoded 0/1 (the interpreter's store is unchanged; the compiled element read compares to zero, a write stores 1/0), so their array machinery needs nothing new — the `BGet`/`BoolE` tags carry the distinction.

## Scope

This completes booleans: scalars, equality, guards, specifications, parameters, copy inference, and now arrays, across interpret / verify / native compile, with assertions type-checked.

## Testing

Behaviour-preserving for integer arrays: every existing fixture, README snippet, and `example.cav` verifies unchanged. `dune build`, `@fmt`, `runtest`, and `@doc` all pass. Verified end-to-end (verify / run / native compile agree) with a flag array read as a guard and a filled boolean array proved all-true via a quantified invariant and postcondition, plus type-error fixtures (a boolean element in arithmetic, an integer array element used as a proposition).

Note (pre-existing, surfaced while testing): the logic grammar has no `( … )` around a quantifier, so a parenthesised `(forall …)` in an assertion does not parse — unrelated to this change, and worth a small follow-up.