### PR TITLE
feat: counterexamples in the browser verifier

### DIFF
--- a/src/hoare.ml
+++ b/src/hoare.ml
@@ -857,20 +857,30 @@ let verify ?debug ?timeout ?machine_int program =
    prover -- the strings are solved client-side in a Z3-wasm worker. Returns, per
    procedure, its name paired with its obligations as [(explanation, smtlib)]. *)
 let obligations_smtlib ?(machine_int = false) program =
+  (* Discard any counterexample state a previous (now superseded) pass retained
+     before minting fresh handles for this one. *)
+  Smt.Prover.reset_browser_ce ();
   let procs, (main, globals) = split_last program in
   let step ~is_main (proc_map, acc) proc =
     let (t : Triple.t) = fst proc in
     let proc_map' =
       if is_main then proc_map else Proc_map.add t.f proc proc_map
     in
-    let obligations, uses_map, _ =
+    let obligations, uses_map, merged_vars =
       build_obligations ~machine_int ~is_main globals proc_map' proc
     in
     let smt =
       List.map
         (fun (f, expl, loc) ->
           let task = Arith.task ~div:(Arith.uses_div f) ~map:uses_map in
-          (expl, Option.map Loc.of_why3 loc, Smt.Prover.smtlib_of_term task f))
+          (* Alongside the verdict obligation, print its counterexample twin: on
+             failure the worker solves [ce] to recover a model (see
+             [Smt.Prover.smtlib_ce_of_obligation]). *)
+          let ce = Smt.Prover.smtlib_ce_of_obligation task merged_vars f in
+          ( expl,
+            Option.map Loc.of_why3 loc,
+            Smt.Prover.smtlib_of_term task f,
+            ce ))
         obligations
     in
     (proc_map', (t.f, smt) :: acc)
@@ -903,3 +913,16 @@ let format_counterexample ?status ce =
       in
       let line (n, v) = Printf.sprintf "    %s = %s\n" n v in
       header ^ String.concat "" (List.map line visible)
+
+(* Browser end of the counterexample path: parse the model Z3-wasm produced for
+   the obligation printed under [handle] and render it exactly as the native CLI
+   does -- through the shared [render_counterexample]/[format_counterexample]. A
+   [candidate] witness (Z3-wasm answered [unknown], not [sat]) is flagged
+   unconfirmed. Empty string when there is nothing user-facing to show. *)
+let render_browser_counterexample ?(candidate = true) handle output =
+  let status =
+    if candidate then Smt.Prover.Candidate else Smt.Prover.Disproved
+  in
+  Smt.Prover.browser_ce handle output
+  |> render_counterexample
+  |> format_counterexample ~status

--- a/src/hoare.mli
+++ b/src/hoare.mli
@@ -39,13 +39,16 @@ val verify :
 val obligations_smtlib :
   ?machine_int:bool ->
   (Triple.t * Vars.t) list ->
-  (string * (string * Loc.t option * string) list) list
+  (string * (string * Loc.t option * string * (string * int) option) list) list
 (** Browser path: print every proof obligation of every procedure to SMT-LIB2
     instead of proving it. Returns, per procedure, its name paired with its
-    obligations as [(explanation, location, smtlib)]; [location] is the source
-    position of the offending construct ([None] for whole-procedure obligations
-    like a plain postcondition). The strings are solved client-side in a Z3-wasm
-    worker; no prover is run here. *)
+    obligations as [(explanation, location, smtlib, counterexample)]; [location]
+    is the source position of the offending construct ([None] for
+    whole-procedure obligations like a plain postcondition), and
+    [counterexample] is the [(ce_smtlib, handle)] twin the worker solves on
+    failure to recover a model ([None] if no counterexamples driver is loaded).
+    The strings are solved client-side in a Z3-wasm worker; no prover is run
+    here. *)
 
 (** Why a verification obligation failed. Recovered from the failing subgoal's
     explanation attribute; see {!expl_of_reason} for the human wording. *)
@@ -91,6 +94,14 @@ val format_counterexample :
     string if nothing user-facing remains after hiding internal symbols).
     [status] qualifies the witness -- a [Candidate] one is flagged unconfirmed.
 *)
+
+val render_browser_counterexample : ?candidate:bool -> int -> string -> string
+(** Browser path: parse the Z3-wasm model [output] for the counterexample
+    obligation printed under [handle] (see {!obligations_smtlib}) and render it
+    to the same display block as {!format_counterexample}. [candidate] (default
+    [true]) flags the witness unconfirmed -- pass [false] only when Z3-wasm
+    answered [sat] rather than [unknown]. Empty string if nothing user-facing
+    remains. *)
 
 val verify_report :
   ?debug:bool ->

--- a/src/main.ml
+++ b/src/main.ml
@@ -44,6 +44,7 @@ let get_ast_string ?(fname = "<input>") src =
 let verify = Hoare.verify
 let verify_report = Hoare.verify_report
 let obligations_smtlib = Hoare.obligations_smtlib
+let render_browser_counterexample = Hoare.render_browser_counterexample
 
 let exec path =
   get_ast path |> List.map (fun p -> fst p |> Runtime.to_proc_t) |> Runtime.exec

--- a/src/main.mli
+++ b/src/main.mli
@@ -26,9 +26,14 @@ val verify :
 val obligations_smtlib :
   ?machine_int:bool ->
   (Triple.t * Vars.t) list ->
-  (string * (string * Ast.Loc.t option * string) list) list
+  (string * (string * Ast.Loc.t option * string * (string * int) option) list)
+  list
 (** Print every proof obligation to SMT-LIB2 instead of proving it (the browser
     path). See {!Hoare.obligations_smtlib}. *)
+
+val render_browser_counterexample : ?candidate:bool -> int -> string -> string
+(** Parse and render a Z3-wasm counterexample model for the browser path. See
+    {!Hoare.render_browser_counterexample}. *)
 
 val verify_report :
   ?debug:bool ->

--- a/src/smt/prover.ml
+++ b/src/smt/prover.ml
@@ -9,13 +9,21 @@ open Why3
    theories from the embedded loadpath, and the driver is loaded from an embedded
    [.drv] via a hand-built [config_prover] with the datadir pinned to the
    embedded tree -- bypassing detection entirely. On native builds [browser] is
-   [None] and the original Whyconf path runs unchanged. *)
-type browser_env = { loadpath : string list; driver_file : string }
+   [None] and the original Whyconf path runs unchanged.
+
+   [ce_driver_file] is the embedded counterexamples driver (Z3's
+   [z3_487_counterexample.drv]); it drives the browser's best-effort
+   counterexample path the same way [z3_ce] does natively. *)
+type browser_env = {
+  loadpath : string list;
+  driver_file : string;
+  ce_driver_file : string;
+}
 
 let browser : browser_env option ref = ref None
 
-let configure_browser ~loadpath ~driver_file =
-  browser := Some { loadpath; driver_file }
+let configure_browser ~loadpath ~driver_file ~ce_driver_file =
+  browser := Some { loadpath; driver_file; ce_driver_file }
 
 (* Why3 configuration and the Z3 driver are loaded *lazily*: OCaml evaluates
    every linked module's top-level bindings at process startup, so binding these
@@ -136,6 +144,23 @@ let z3_ce =
              Driver.load_driver_for_prover (Lazy.force main) (Lazy.force env) cp
            )
      with _ -> None)
+
+(* The browser counterpart to [z3_ce]. Native config detection is unavailable in
+   the browser (see [config]), so the counterexamples driver is loaded from the
+   embedded [.drv] via a hand-built [config_prover], exactly as [z3_driver] loads
+   the plain one. [None] on native builds (the [z3_ce] path is used there) and,
+   best-effort, if the embedded driver fails to load -- the browser then simply
+   shows no counterexample. *)
+let browser_ce_driver =
+  lazy
+    (match !browser with
+    | None -> None
+    | Some b -> (
+        try
+          let cp = browser_config_prover b.ce_driver_file in
+          Some
+            (Driver.load_driver_for_prover (Lazy.force main) (Lazy.force env) cp)
+        with _ -> None))
 
 type result = Valid | Invalid | Failed of string [@@deriving sexp_of, ord]
 
@@ -265,6 +290,19 @@ let skolemise f =
       (consts, Term.t_subst map body)
   | _ -> ([], f)
 
+(* Extract the [(name, value)] assignments a Why3 [model] gives the *source*
+   variables named in [expose_names], dropping the WLP's internal havoc/variant
+   vars (introduced existentially in the negation) and anything not exposed.
+   Shared by the native and browser counterexample paths, which differ only in
+   how they obtain the [model]. *)
+let expose_model_elements expose_names model =
+  Model_parser.get_model_elements model
+  |> List.map ~f:(fun (e : Model_parser.model_element) ->
+      ( Model_parser.get_lsymbol_or_model_trace_name e,
+        e.Model_parser.me_concrete_value ))
+  |> List.filter ~f:(fun (n, _) -> Set.mem expose_names n)
+  |> List.dedup_and_sort ~compare:(fun (a, _) (b, _) -> String.compare a b)
+
 (* Best-effort counterexample for a failed obligation [f] (a split subgoal):
    skolemise its entry-state variables into model-reportable constants, ask Z3's
    counterexamples driver for a model, and return the [(name, value)] pairs it
@@ -300,11 +338,80 @@ let counterexample timeout base_task expose f =
       in
       match r.Call_provers.pr_models with
       | [] -> []
-      | (_, model) :: _ ->
-          Model_parser.get_model_elements model
-          |> List.map ~f:(fun (e : Model_parser.model_element) ->
-              ( Model_parser.get_lsymbol_or_model_trace_name e,
-                e.Model_parser.me_concrete_value ))
-          |> List.filter ~f:(fun (n, _) -> Set.mem expose_names n)
-          |> List.dedup_and_sort ~compare:(fun (a, _) (b, _) ->
-              String.compare a b))
+      | (_, model) :: _ -> expose_model_elements expose_names model)
+
+(* {2 Browser counterexample path}
+
+   Native [counterexample] both runs Z3 (via [wait_on_call]) and parses its
+   model, because Why3 spawns the prover as a subprocess. In the browser Z3-wasm
+   runs the solver in JavaScript, so the two halves are split: OCaml prints the
+   counterexample obligation to SMT-LIB2 here ([smtlib_ce_of_obligation]), JS
+   solves it, then hands the raw model text back for parsing ([browser_ce]). The
+   [printing_info] the model parser needs -- Why3's map from the printed SMT
+   names back to source symbols -- is retained across that async round-trip in
+   [ce_state], keyed by an integer handle returned to JS with the SMT-LIB2. *)
+
+let ce_state : (int, Printer.printing_info * String.Set.t) Hashtbl.t =
+  Hashtbl.create (module Int)
+
+let ce_counter = ref 0
+
+(* Clear the retained [printing_info]s and restart handles from 0. Called at the
+   start of each obligation-printing pass so a superseded run's state cannot
+   accumulate or be mistaken for the current one's. *)
+let reset_browser_ce () =
+  Hashtbl.clear ce_state;
+  ce_counter := 0
+
+(* Print the counterexample obligation for [f] to SMT-LIB2 and stash the
+   [printing_info] under a fresh handle, returned with the text. The
+   counterexamples driver makes the printer emit [(set-option :produce-models
+   true)] and a trailing [(get-model)], so Z3's output on [sat] carries the model
+   for [browser_ce] to parse. [None] if no CE driver is loaded (native, or a
+   failed embedded load). *)
+let smtlib_ce_of_obligation base_task expose f =
+  match Lazy.force browser_ce_driver with
+  | None -> None
+  | Some driver ->
+      let consts, body = skolemise f in
+      let task = List.fold_left ~f:Task.add_param_decl ~init:base_task consts in
+      let goal_id = Decl.create_prsymbol (Ident.id_fresh "goal") in
+      let task = Task.add_prop_decl task Decl.Pgoal goal_id body in
+      let task = Driver.prepare_task driver task in
+      let buf = Buffer.create 1024 in
+      let fmt = Format.formatter_of_buffer buf in
+      let info = Driver.print_task_prepared driver fmt task in
+      Format.pp_print_flush fmt ();
+      let expose_names =
+        List.map ~f:(fun v -> v.Term.vs_name.Ident.id_string) expose
+        |> String.Set.of_list
+      in
+      let id = !ce_counter in
+      Int.incr ce_counter;
+      Hashtbl.set ce_state ~key:id ~data:(info, expose_names);
+      Some (Buffer.contents buf, id)
+
+let smtv2_model_parser = lazy (Model_parser.lookup_model_parser "smtv2")
+
+(* Z3's raw output is the answer token ([sat]/[unknown]) followed by the model
+   s-expression; the smtv2 model parser wants that s-expression alone (native
+   [Call_provers] likewise feeds it only the post-answer text). Slice from the
+   first [(]. *)
+let model_sexp_of_output out =
+  match String.index out '(' with
+  | Some i -> String.subo out ~pos:i
+  | None -> ""
+
+(* Parse the model Z3-wasm produced for the obligation printed under [id],
+   returning the same [(name, value)] pairs as native [counterexample]: the
+   source variables named in the stashed expose set, dropping WLP-internal vars.
+   Empty if the handle is unknown (a superseded run) or no model was produced. *)
+let browser_ce id output =
+  match Hashtbl.find ce_state id with
+  | None -> []
+  | Some (info, expose_names) ->
+      let sexp = model_sexp_of_output output in
+      if String.is_empty (String.strip sexp) then []
+      else
+        let model = (Lazy.force smtv2_model_parser) info sexp in
+        expose_model_elements expose_names model

--- a/src/smt/prover.mli
+++ b/src/smt/prover.mli
@@ -6,13 +6,15 @@
 
 open Why3
 
-val configure_browser : loadpath:string list -> driver_file:string -> unit
-(** Switch the SMT layer to the browser path: build {!env} and the print driver
+val configure_browser :
+  loadpath:string list -> driver_file:string -> ce_driver_file:string -> unit
+(** Switch the SMT layer to the browser path: build {!env} and the print drivers
     from files embedded in the js_of_ocaml pseudo-filesystem instead of via Why3
     config detection (which needs a real filesystem and Z3 binary). Must be
-    called -- with the embedded stdlib loadpath and an embedded [.drv] path --
-    before anything forces {!env}. A no-op's inverse: on native builds this is
-    never called and Whyconf detection runs as before. *)
+    called -- with the embedded stdlib loadpath, an embedded plain [.drv], and
+    the embedded counterexamples [.drv] -- before anything forces {!env}. A
+    no-op's inverse: on native builds this is never called and Whyconf detection
+    runs as before. *)
 
 val env : Env.env Lazy.t
 (** The Why3 environment (theory load path), shared so callers can build tasks
@@ -87,3 +89,26 @@ val counterexample :
     display -- notably expanding an array's map literal into a concrete list.
     Best-effort and advisory: [[]] if no CE prover is configured or no model was
     produced, so it never affects the verdict. *)
+
+val reset_browser_ce : unit -> unit
+(** Clear the state {!smtlib_ce_of_obligation} retains between printing an
+    obligation and parsing its model. Call at the start of each obligation pass
+    so a superseded run cannot accumulate or leak state into the next. *)
+
+val smtlib_ce_of_obligation :
+  Task.task -> Term.vsymbol list -> Term.term -> (string * int) option
+(** The browser split of {!counterexample}'s printing half: serialise the
+    counterexample obligation for [f] (exposing the entry-state variables
+    [expose]) to SMT-LIB2 whose Z3 output carries a model, and stash the Why3
+    [printing_info] under a fresh integer handle. Returns [(smtlib, handle)];
+    the caller solves [smtlib] in Z3-wasm and passes the output back with
+    [handle] to {!browser_ce}. [None] if no counterexamples driver is loaded
+    (native builds, or a failed embedded load). *)
+
+val browser_ce :
+  int -> string -> (string * Model_parser.concrete_syntax_term) list
+(** [browser_ce handle output] parses the Z3-wasm [output] for the obligation
+    printed under [handle] by {!smtlib_ce_of_obligation}, returning the same
+    exposed [(variable, value)] pairs as native {!counterexample}. [[]] if the
+    handle is unknown (a superseded run cleared by {!reset_browser_ce}) or no
+    model was produced. *)

--- a/web/README.md
+++ b/web/README.md
@@ -18,15 +18,15 @@ and the JS half feeds those strings to Z3-wasm.
     │  source string
     ▼
  verifier.bc.js         OCaml pipeline compiled by js_of_ocaml
-    │  cavalryObligations(src) -> JSON { procedures:[ obligations:[ smtlib ] ] }
+    │  cavalryObligations(src) -> JSON { procedures:[ obligations:[ smtlib, ceSmtlib, ceId ] ] }
     ▼
  verify-core.js         async solve loop (one Z3 context per obligation)
-    │  smtlib
+    │  smtlib          (on failure: ceSmtlib -> raw model -> cavalryRenderCounterexample(ceId, …))
     ▼
  z3-built.js + .wasm    Z3 4.16, Emscripten; solves in its own worker threads
     │  unsat | sat | unknown
     ▼
- verdict + located diagnostics
+ verdict + located diagnostics + counterexample
 ```
 
 Everything runs on the main thread. `cavalryObligations` is a fast synchronous
@@ -42,6 +42,21 @@ filesystem in the browser, they are embedded (via `ocaml-crunch`) and served
 into the js_of_ocaml pseudo-filesystem with `Sys_js.mount`. `Smt.Prover`'s
 browser hook then builds the environment and driver from those, bypassing
 Why3's prover-detection (which needs a native Z3 binary).
+
+A failed obligation also carries a *counterexample* — the entry-state values
+that break the spec. Natively, Why3 runs Z3 and parses its model in one call;
+in the browser those halves are split across the same seam as the verdict. Each
+obligation is printed a second time with the *counterexamples* driver (which
+emits `(get-model)`), and the Why3 `printing_info` that maps the printed SMT
+names back to source variables is retained under the integer `ceId`. On a `sat`
+answer, `verify-core.js` hands the raw model text and `ceId` back to
+`cavalryRenderCounterexample`, which parses the model with Why3's `smtv2` parser
+and renders it through the *same* `render_counterexample`/`format_counterexample`
+the native CLI uses — arrays expanded, internal WLP variables hidden. The
+counterexample driver is a non-incremental variant (`z3_487_ce_batch.drv`),
+since the stock one emits a `(check-sat)` per incremental step and Z3-wasm
+evaluates the whole script at once. It is best-effort: a model that fails to
+parse leaves the verdict untouched and simply shows no witness.
 
 ## Editor
 

--- a/web/app.js
+++ b/web/app.js
@@ -158,6 +158,8 @@ async function verifyNow() {
     onProgress: (done, total) => {
       if (myGen === currentGen) setPill("busy", `verifying… ${done}/${total}`);
     },
+    renderCounterexample: (id, output, candidate) =>
+      self.cavalryRenderCounterexample(id, output, candidate),
   });
   if (myGen !== currentGen || result.stale) return; // superseded
   render(myGen, result);
@@ -238,6 +240,13 @@ function render(gen, result, { stale } = {}) {
       v.className = "note";
       v.textContent = `  (${f.verdict})`;
       li.append(v);
+      // A counterexample block (variable = value lines), when Z3 produced one.
+      if (f.counterexample) {
+        const pre = document.createElement("pre");
+        pre.className = "counterexample";
+        pre.textContent = f.counterexample.replace(/\n$/, "");
+        li.append(pre);
+      }
       ul.appendChild(li);
     }
     results.appendChild(ul);

--- a/web/e2e-browser.cjs
+++ b/web/e2e-browser.cjs
@@ -110,7 +110,11 @@ async function setEditor(page, text) {
     await waitPill(page, /not verified/, "broken postcondition -> not verified");
     const fail = await page.$eval("#results", (el) => el.textContent);
     if (!/postcondition may not hold/.test(fail)) throw new Error("missing failure explanation: " + fail);
-    console.log("  ok: failure explanation shown");
+    // The failure carries a counterexample: an entry-state witness (x = ...)
+    // under a "counterexample:" heading, parsed from Z3's model.
+    if (!/counterexample:/.test(fail) || !/\bx = /.test(fail))
+      throw new Error("missing counterexample: " + fail);
+    console.log("  ok: failure explanation + counterexample shown");
 
     // 3. Fix it -> verified again.
     await setEditor(page, `{ x >= 0 }\ny := x + 1\n{ y > x }`);

--- a/web/e2e-node.cjs
+++ b/web/e2e-node.cjs
@@ -11,16 +11,22 @@ const programs = {
   syntax:  `{ x >= 0 }\ny := x +\n{ y > x }`,
 };
 
+const renderCounterexample = (id, output, candidate) =>
+  globalThis.cavalryRenderCounterexample(id, output, candidate);
+
 (async () => {
   const { Z3 } = await init();
   const solve = makeSolver(Z3);
   for (const [name, src] of Object.entries(programs)) {
     const parsed = JSON.parse(globalThis.cavalryObligations(src));
-    const res = await solveObligations(parsed, solve);
+    const res = await solveObligations(parsed, solve, { renderCounterexample });
     if (!res.ok) { console.log(`${name.padEnd(8)} -> ${res.kind} error: ${res.error} @ ${JSON.stringify(res.loc)}`); continue; }
     const status = res.verified ? 'VERIFIED' : `FAILED (${res.failures.length}/${res.total})`;
     console.log(`${name.padEnd(8)} -> ${status} [${res.total} obligations]`);
-    for (const f of res.failures) console.log(`             x ${f.proc}: ${f.expl} (${f.verdict}) @ ${JSON.stringify(f.loc)}`);
+    for (const f of res.failures) {
+      console.log(`             x ${f.proc}: ${f.expl} (${f.verdict}) @ ${JSON.stringify(f.loc)}`);
+      if (f.counterexample) for (const line of f.counterexample.replace(/\n$/, '').split('\n')) console.log(`             ${line}`);
+    }
   }
   process.exit(0);
 })();

--- a/web/index.html
+++ b/web/index.html
@@ -176,6 +176,14 @@
         font-size: 12px;
       }
       ul.findings li.err { border-left-color: var(--busy); background: color-mix(in srgb, var(--busy) 10%, transparent); }
+      .counterexample {
+        margin: 6px 0 0;
+        color: var(--muted);
+        font-family: var(--mono);
+        font-size: 12px;
+        white-space: pre;
+        overflow-x: auto;
+      }
       .loc { color: var(--accent); cursor: pointer; }
       .progress {
         height: 4px;

--- a/web/m0.ml
+++ b/web/m0.ml
@@ -51,7 +51,7 @@ let () =
         (fun (name, obligations) ->
           let name = if String.equal name "" then "<main>" else name in
           List.iteri
-            (fun i (expl, _loc, smtlib) ->
+            (fun i (expl, _loc, smtlib, _ce) ->
               Printf.printf "@@@ %s / %s / obligation %d: %s\n%s\n@@@END\n"
                 label name i expl smtlib)
             obligations)

--- a/web/verifier.ml
+++ b/web/verifier.ml
@@ -9,9 +9,14 @@
 
    JSON shape:
      ok:    { "ok": true, "procedures": [ { "name", "obligations":
-              [ { "expl", "loc": {"line","col"}|null, "smtlib" } ] } ] }
+              [ { "expl", "loc": {"line","col"}|null, "smtlib",
+                  "ceSmtlib": string|null, "ceId": int|null } ] } ] }
      error: { "ok": false, "kind": "lex"|"parse"|"type",
-              "error": string, "loc": {"line","col"}|null } *)
+              "error": string, "loc": {"line","col"}|null }
+
+   [ceSmtlib]/[ceId] are the counterexample twin of an obligation: on failure the
+   worker solves [ceSmtlib] and passes its output back through
+   [cavalryRenderCounterexample] with [ceId]. Both null if no CE driver loaded. *)
 
 open Js_of_ocaml
 module Loc = Ast.Loc
@@ -25,6 +30,7 @@ let () =
   Sys_js.mount ~path:"/why3/" (fun ~prefix:_ ~path -> Embedded_why3.read path);
   Smt.Prover.configure_browser ~loadpath:[ "/why3/stdlib" ]
     ~driver_file:"/why3/drivers/z3_487.drv"
+    ~ce_driver_file:"/why3/drivers/z3_487_ce_batch.drv"
 
 let json_of_loc : Loc.t option -> Yojson.Safe.t = function
   | None -> `Null
@@ -77,12 +83,19 @@ let verify_json (src : string) : string =
       |> Ast.Var_collection.collect |> Cavalry.Main.obligations_smtlib
     with
     | procs ->
-        let obligation (expl, loc, smtlib) : Yojson.Safe.t =
+        let obligation (expl, loc, smtlib, ce) : Yojson.Safe.t =
+          let ce_smtlib, ce_id =
+            match ce with
+            | Some (s, id) -> (`String s, `Int id)
+            | None -> (`Null, `Null)
+          in
           `Assoc
             [
               ("expl", `String expl);
               ("loc", json_of_loc loc);
               ("smtlib", `String smtlib);
+              ("ceSmtlib", ce_smtlib);
+              ("ceId", ce_id);
             ]
         in
         let procedure (name, obs) : Yojson.Safe.t =
@@ -107,3 +120,14 @@ let verify_json (src : string) : string =
 let () =
   Js.Unsafe.set Js.Unsafe.global "cavalryObligations"
     (Js.wrap_callback (fun src -> Js.string (verify_json (Js.to_string src))))
+
+(* [cavalryRenderCounterexample(ceId, output, candidate)]: parse the Z3-wasm
+   model [output] for the counterexample obligation [ceId] and return the
+   rendered display block (empty string if there is nothing to show). The worker
+   calls this only for a failing obligation whose [ceSmtlib] it has just solved. *)
+let () =
+  Js.Unsafe.set Js.Unsafe.global "cavalryRenderCounterexample"
+    (Js.wrap_callback (fun ce_id output candidate ->
+         Js.string
+           (Cavalry.Main.render_browser_counterexample
+              ~candidate:(Js.to_bool candidate) ce_id (Js.to_string output))))

--- a/web/verify-core.js
+++ b/web/verify-core.js
@@ -26,14 +26,22 @@ function makeSolver(Z3) {
 // failure. [isStale] is polled between obligations so a superseded run (the user
 // typed again) bails without finishing -- cancellation without terminating the
 // worker. [onProgress] reports (done, total) for the UI.
+//
+// [renderCounterexample(ceId, output, candidate) -> string] is optional: when
+// given, a failing obligation's counterexample twin ([ceSmtlib]) is solved and
+// its model rendered to a display block attached as [failure.counterexample].
+// [candidate] is false only when Z3 answered [sat] (a confirmed refutation).
 async function solveObligations(parsed, solve, opts) {
   opts = opts || {};
-  const { onProgress, isStale } = opts;
+  const { onProgress, isStale, renderCounterexample } = opts;
   if (!parsed.ok) return parsed;
   const all = [];
   for (const p of parsed.procedures) {
     for (const o of p.obligations) {
-      all.push({ proc: p.name || "<main>", expl: o.expl, loc: o.loc, smtlib: o.smtlib });
+      all.push({
+        proc: p.name || "<main>", expl: o.expl, loc: o.loc,
+        smtlib: o.smtlib, ceSmtlib: o.ceSmtlib, ceId: o.ceId,
+      });
     }
   }
   const total = all.length;
@@ -43,7 +51,14 @@ async function solveObligations(parsed, solve, opts) {
     if (isStale && isStale()) return { ok: true, stale: true };
     const answer = await solve(ob.smtlib);
     if (answer !== "unsat") {
-      failures.push({ proc: ob.proc, expl: ob.expl, loc: ob.loc, verdict: answer });
+      let counterexample = "";
+      if (renderCounterexample && ob.ceSmtlib != null && ob.ceId != null) {
+        // The CE twin embeds (get-model), so its output is the answer token
+        // followed by the model; [candidate] unless Z3 confirmed with [sat].
+        const ceOut = await solve(ob.ceSmtlib);
+        counterexample = renderCounterexample(ob.ceId, ceOut, !ceOut.startsWith("sat"));
+      }
+      failures.push({ proc: ob.proc, expl: ob.expl, loc: ob.loc, verdict: answer, counterexample });
     }
     done += 1;
     if (onProgress) onProgress(done, total);

--- a/web/why3data/drivers/z3_487_ce_batch.drv
+++ b/web/why3data/drivers/z3_487_ce_batch.drv
@@ -1,0 +1,16 @@
+(* Non-incremental counterexample driver for the browser's one-shot Z3-wasm
+   eval. The stock [z3_487_counterexample.drv] also sets [meta_incremental],
+   which makes the SMT-LIB2 printer emit a (push)(check-sat)(get-model) block per
+   incremental step -- correct when why3server drives Z3 command-by-command, but
+   here the whole script is handed to [eval_smtlib2_string] at once, so the
+   doubled check-sat yields two models and breaks parsing. This variant keeps
+   only [get_counterexmp] (which turns on :produce-models and a single trailing
+   (get-model)), inheriting everything else from the plain driver. *)
+
+import "z3_487.drv"
+
+theory BuiltIn
+
+  meta "get_counterexmp" ""
+
+end


### PR DESCRIPTION
## What

A failed obligation in the web UI now shows the entry-state values that break the spec — a counterexample block under the reason/location, e.g.:

```
main: postcondition may not hold  line 3:1
  counterexample:
    x = 0
    y = 0
```

Previously the browser reported only the reason and location; the counterexample machinery lived entirely in the native `cav verify` path.

## How

Natively, Why3 runs Z3 and parses its model in one `wait_on_call`. The browser's solver is Z3-wasm in JavaScript, so the two halves are split across the existing OCaml-prints / JS-solves seam — and the **rendering is reused verbatim**, not reimplemented:

1. `obligations_smtlib` prints each obligation a *second* time with a counterexamples driver (which emits `(get-model)`), retaining the Why3 `printing_info` — the map from printed SMT names back to source variables — under an integer handle (`ceId`) returned to JS alongside the verdict SMT-LIB2.
2. On a non-`unsat` answer, `verify-core.js` solves the twin and hands the raw model text + `ceId` to `cavalryRenderCounterexample`.
3. `render_browser_counterexample` parses the model with Why3's `smtv2` parser (`Model_parser.model_parser`) and renders it through the same `render_counterexample`/`format_counterexample` the CLI uses — arrays expanded via `#len#`, internal WLP variables hidden, candidate-vs-disproved header set by whether Z3 answered `unknown` or `sat`.

## Non-incremental CE driver

`z3_487_ce_batch.drv` is a new non-incremental variant. The stock `z3_487_counterexample.drv` sets `meta_incremental`, which makes the batch printer emit a `(check-sat)(get-model)` per incremental step — correct when why3server drives Z3 command-by-command, but Z3-wasm's `eval_smtlib2_string` runs the whole script at once and returned two models, breaking the parser.

## Notes

- Best-effort and never affects the verdict: a model that fails to parse simply shows no witness.
- The native prove path is unchanged (still `wait_on_call`); the standalone parser is used only where the solver isn't a spawnable process.
- Arrays with quantified postconditions can still hang the browser's *verdict* solve — a pre-existing z3-wasm-on-maps limitation (no browser solve timeout), unrelated to this change.

## Testing

- `dune build`, `dune build --profile web`, `dune runtest`, `dune build @doc`, `dune build @fmt` — clean.
- **node e2e** (`e2e-node.cjs`): the `invalid` program renders `x = 0, y = 0`.
- **browser e2e** (`e2e-browser.cjs`, real Chrome): new assertion "failure explanation + counterexample shown" passes; all checks green.