### PR TITLE
docs(readme): pare front-page examples to loops and recursion

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,26 +49,12 @@ operation must additionally be proven not to overflow.
 
 ## Examples
 
-The three examples below cover the core constructs; the rest — returning
-values, arrays with `forall`/`exists`, booleans, recursion, and how a failed
-proof is reported — are in [Cavalry by example](assets/readme-snippets/EXAMPLES.md).
-Each is a standalone program in [`assets/readme-snippets/snippets/`](assets/readme-snippets/snippets);
+The two examples below cover loops and recursive procedures; the rest —
+straight-line Hoare triples, returning values, arrays with `forall`/`exists`,
+booleans, division and modulo, and how a failed proof is reported — are in
+[Cavalry by example](assets/readme-snippets/EXAMPLES.md). Each is a standalone
+program in [`assets/readme-snippets/snippets/`](assets/readme-snippets/snippets);
 verify any of them with `dune exec -- cav verify <file>`.
-
-### A Hoare triple
-
-Verification rests on the Hoare triple `{P} c {Q}`: if precondition `P` holds
-before command `c` runs, postcondition `Q` holds afterwards. The simplest
-programs are straight-line assignments, with no loops or procedures.
-
-<!-- snippet: hoare-triple -->
-<a href="assets/readme-snippets/snippets/hoare-triple.cav">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="assets/snippet-hoare-triple-dark.svg">
-    <img alt="Cavalry code snippet" src="assets/snippet-hoare-triple-light.svg">
-  </picture>
-</a>
-<!-- /snippet -->
 
 ### Computing triangle numbers
 
@@ -85,19 +71,19 @@ iteration — proves termination, giving total correctness.
 </a>
 <!-- /snippet -->
 
-### Procedures and contracts
+### Procedures, contracts, and recursion
 
 A procedure is verified once against its contract: `requires` and `ensures` are
 its pre- and postcondition, and `writes` frames the globals it may modify.
-Callers reason from the contract alone, not from the body. Division `/` and
-modulo `%` are part of the logic, so the postcondition can name the result
-directly.
+Callers — including the procedure itself, when it recurses — reason from the
+contract alone, not from the body. A `variant` that strictly decreases at each
+recursive call proves the recursion terminates, giving total correctness.
 
-<!-- snippet: euclidean-division -->
-<a href="assets/readme-snippets/snippets/euclidean-division.cav">
+<!-- snippet: recursive-procedure -->
+<a href="assets/readme-snippets/snippets/recursive-procedure.cav">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="assets/snippet-euclidean-division-dark.svg">
-    <img alt="Cavalry code snippet" src="assets/snippet-euclidean-division-light.svg">
+    <source media="(prefers-color-scheme: dark)" srcset="assets/snippet-recursive-procedure-dark.svg">
+    <img alt="Cavalry code snippet" src="assets/snippet-recursive-procedure-light.svg">
   </picture>
 </a>
 <!-- /snippet -->

--- a/assets/readme-snippets/EXAMPLES.md
+++ b/assets/readme-snippets/EXAMPLES.md
@@ -3,9 +3,9 @@
 Short, self-contained programs, each exercising one part of the language. Each
 is a real file in [`snippets/`](snippets); verify any of them with `dune exec --
 cav verify <file>` (see the [top-level README](../../README.md#usage) for setup).
-The three marked ★ also appear on the front page.
+The two marked ★ also appear on the front page.
 
-## A Hoare triple ★
+## A Hoare triple
 
 Verification rests on the Hoare triple `{P} c {Q}`: if precondition `P` holds
 before command `c` runs, postcondition `Q` holds afterwards. The simplest
@@ -35,7 +35,7 @@ iteration — proves termination, giving total correctness.
 </a>
 <!-- /snippet -->
 
-## Procedures and contracts ★
+## Procedures and contracts
 
 A procedure is verified once against its contract: `requires` and `ensures` are
 its pre- and postcondition, and `writes` frames the globals it may modify.
@@ -112,10 +112,11 @@ specification, and an `if` may drop its `else` when the missing branch is a no-o
 </a>
 <!-- /snippet -->
 
-## Recursion
+## Recursion ★
 
-Procedures may call themselves. A `variant` on the procedure — decreasing across
-each recursive call — proves the recursion terminates, just as it does for a loop.
+Procedures may call themselves, reasoning from their own contract at the
+recursive call. A `variant` on the procedure — decreasing across each recursive
+call — proves the recursion terminates, just as it does for a loop.
 
 <!-- snippet: recursive-procedure -->
 <a href="snippets/recursive-procedure.cav">

--- a/assets/readme-snippets/snippets/recursive-procedure.cav
+++ b/assets/readme-snippets/snippets/recursive-procedure.cav
@@ -1,18 +1,19 @@
-// A procedure may call itself. The `variant` strictly decreases across each
-// recursive call, which is what proves the recursion terminates.
+// A procedure may call itself. Its contract carries across the recursive call:
+// the `ensures` proved for `sum_to(n - 1)` is what the body reasons from, and
+// the `variant` — strictly decreasing at each call — proves it terminates.
 procedure sum_to (n) =
   requires { n >= 0 }
-  ensures { s >= 0 }
+  ensures { 2 * s = n * (n + 1) }
   variant { n }
   writes { s }
   if n = 0 then
     s := 0
   else
-    sum_to(n - 1);
-    s := s + n
+    sum_to(n - 1);  // 2 * s = (n - 1) * n
+    s := s + n      // 2 * s = n * (n + 1)
   end
 end
 
 { true }
 sum_to(5)
-{ s >= 0 }
+{ 2 * s = 30 }  // 1 + 2 + 3 + 4 + 5 = 15

--- a/assets/snippet-recursive-procedure-dark.svg
+++ b/assets/snippet-recursive-procedure-dark.svg
@@ -1,21 +1,22 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="696" height="410" viewBox="0 0 696 410" font-family='ui-monospace, "SF Mono", Menlo, Consolas, monospace' font-size="14">
+<svg xmlns="http://www.w3.org/2000/svg" width="722" height="431" viewBox="0 0 722 431" font-family='ui-monospace, "SF Mono", Menlo, Consolas, monospace' font-size="14">
   <rect width="100%" height="100%" fill="#1E1E1E" rx="10"/>
-  <text x="18" y="30" xml:space="preserve"><tspan fill="#6A9955">// A procedure may call itself. The `variant` strictly decreases across each</tspan></text>
-  <text x="18" y="51" xml:space="preserve"><tspan fill="#6A9955">// recursive call, which is what proves the recursion terminates.</tspan></text>
-  <text x="18" y="72" xml:space="preserve"><tspan fill="#C586C0">procedure</tspan><tspan fill="#D4D4D4"> </tspan><tspan fill="#569CD6">sum_to</tspan><tspan fill="#D4D4D4"> (</tspan><tspan fill="#9CDCFE">n</tspan><tspan fill="#D4D4D4">) =</tspan></text>
-  <text x="18" y="93" xml:space="preserve"><tspan fill="#D4D4D4">  </tspan><tspan fill="#569CD6" font-style="italic">requires</tspan><tspan fill="#D4D4D4"> { </tspan><tspan fill="#9CDCFE">n</tspan><tspan fill="#D4D4D4"> &gt;= </tspan><tspan fill="#B5CEA8">0</tspan><tspan fill="#D4D4D4"> }</tspan></text>
-  <text x="18" y="114" xml:space="preserve"><tspan fill="#D4D4D4">  </tspan><tspan fill="#569CD6" font-style="italic">ensures</tspan><tspan fill="#D4D4D4"> { </tspan><tspan fill="#9CDCFE">s</tspan><tspan fill="#D4D4D4"> &gt;= </tspan><tspan fill="#B5CEA8">0</tspan><tspan fill="#D4D4D4"> }</tspan></text>
-  <text x="18" y="135" xml:space="preserve"><tspan fill="#D4D4D4">  </tspan><tspan fill="#569CD6" font-style="italic">variant</tspan><tspan fill="#D4D4D4"> { </tspan><tspan fill="#9CDCFE">n</tspan><tspan fill="#D4D4D4"> }</tspan></text>
-  <text x="18" y="156" xml:space="preserve"><tspan fill="#D4D4D4">  </tspan><tspan fill="#569CD6" font-style="italic">writes</tspan><tspan fill="#D4D4D4"> { </tspan><tspan fill="#9CDCFE">s</tspan><tspan fill="#D4D4D4"> }</tspan></text>
-  <text x="18" y="177" xml:space="preserve"><tspan fill="#D4D4D4">  </tspan><tspan fill="#C586C0">if</tspan><tspan fill="#D4D4D4"> </tspan><tspan fill="#9CDCFE">n</tspan><tspan fill="#D4D4D4"> = </tspan><tspan fill="#B5CEA8">0</tspan><tspan fill="#D4D4D4"> </tspan><tspan fill="#C586C0">then</tspan></text>
-  <text x="18" y="198" xml:space="preserve"><tspan fill="#D4D4D4">    </tspan><tspan fill="#9CDCFE">s</tspan><tspan fill="#D4D4D4"> := </tspan><tspan fill="#B5CEA8">0</tspan></text>
-  <text x="18" y="219" xml:space="preserve"><tspan fill="#D4D4D4">  </tspan><tspan fill="#C586C0">else</tspan></text>
-  <text x="18" y="240" xml:space="preserve"><tspan fill="#D4D4D4">    </tspan><tspan fill="#569CD6">sum_to</tspan><tspan fill="#D4D4D4">(</tspan><tspan fill="#9CDCFE">n</tspan><tspan fill="#D4D4D4"> - </tspan><tspan fill="#B5CEA8">1</tspan><tspan fill="#D4D4D4">);</tspan></text>
-  <text x="18" y="261" xml:space="preserve"><tspan fill="#D4D4D4">    </tspan><tspan fill="#9CDCFE">s</tspan><tspan fill="#D4D4D4"> := </tspan><tspan fill="#9CDCFE">s</tspan><tspan fill="#D4D4D4"> + </tspan><tspan fill="#9CDCFE">n</tspan></text>
-  <text x="18" y="282" xml:space="preserve"><tspan fill="#D4D4D4">  </tspan><tspan fill="#C586C0">end</tspan></text>
-  <text x="18" y="303" xml:space="preserve"><tspan fill="#C586C0">end</tspan></text>
-  <text x="18" y="324" xml:space="preserve"></text>
-  <text x="18" y="345" xml:space="preserve"><tspan fill="#D4D4D4">{ </tspan><tspan fill="#569CD6">true</tspan><tspan fill="#D4D4D4"> }</tspan></text>
-  <text x="18" y="366" xml:space="preserve"><tspan fill="#569CD6">sum_to</tspan><tspan fill="#D4D4D4">(</tspan><tspan fill="#B5CEA8">5</tspan><tspan fill="#D4D4D4">)</tspan></text>
-  <text x="18" y="387" xml:space="preserve"><tspan fill="#D4D4D4">{ </tspan><tspan fill="#9CDCFE">s</tspan><tspan fill="#D4D4D4"> &gt;= </tspan><tspan fill="#B5CEA8">0</tspan><tspan fill="#D4D4D4"> }</tspan></text>
+  <text x="18" y="30" xml:space="preserve"><tspan fill="#6A9955">// A procedure may call itself. Its contract carries across the recursive call:</tspan></text>
+  <text x="18" y="51" xml:space="preserve"><tspan fill="#6A9955">// the `ensures` proved for `sum_to(n - 1)` is what the body reasons from, and</tspan></text>
+  <text x="18" y="72" xml:space="preserve"><tspan fill="#6A9955">// the `variant` — strictly decreasing at each call — proves it terminates.</tspan></text>
+  <text x="18" y="93" xml:space="preserve"><tspan fill="#C586C0">procedure</tspan><tspan fill="#D4D4D4"> </tspan><tspan fill="#569CD6">sum_to</tspan><tspan fill="#D4D4D4"> (</tspan><tspan fill="#9CDCFE">n</tspan><tspan fill="#D4D4D4">) =</tspan></text>
+  <text x="18" y="114" xml:space="preserve"><tspan fill="#D4D4D4">  </tspan><tspan fill="#569CD6" font-style="italic">requires</tspan><tspan fill="#D4D4D4"> { </tspan><tspan fill="#9CDCFE">n</tspan><tspan fill="#D4D4D4"> &gt;= </tspan><tspan fill="#B5CEA8">0</tspan><tspan fill="#D4D4D4"> }</tspan></text>
+  <text x="18" y="135" xml:space="preserve"><tspan fill="#D4D4D4">  </tspan><tspan fill="#569CD6" font-style="italic">ensures</tspan><tspan fill="#D4D4D4"> { </tspan><tspan fill="#B5CEA8">2</tspan><tspan fill="#D4D4D4"> * </tspan><tspan fill="#9CDCFE">s</tspan><tspan fill="#D4D4D4"> = </tspan><tspan fill="#9CDCFE">n</tspan><tspan fill="#D4D4D4"> * (</tspan><tspan fill="#9CDCFE">n</tspan><tspan fill="#D4D4D4"> + </tspan><tspan fill="#B5CEA8">1</tspan><tspan fill="#D4D4D4">) }</tspan></text>
+  <text x="18" y="156" xml:space="preserve"><tspan fill="#D4D4D4">  </tspan><tspan fill="#569CD6" font-style="italic">variant</tspan><tspan fill="#D4D4D4"> { </tspan><tspan fill="#9CDCFE">n</tspan><tspan fill="#D4D4D4"> }</tspan></text>
+  <text x="18" y="177" xml:space="preserve"><tspan fill="#D4D4D4">  </tspan><tspan fill="#569CD6" font-style="italic">writes</tspan><tspan fill="#D4D4D4"> { </tspan><tspan fill="#9CDCFE">s</tspan><tspan fill="#D4D4D4"> }</tspan></text>
+  <text x="18" y="198" xml:space="preserve"><tspan fill="#D4D4D4">  </tspan><tspan fill="#C586C0">if</tspan><tspan fill="#D4D4D4"> </tspan><tspan fill="#9CDCFE">n</tspan><tspan fill="#D4D4D4"> = </tspan><tspan fill="#B5CEA8">0</tspan><tspan fill="#D4D4D4"> </tspan><tspan fill="#C586C0">then</tspan></text>
+  <text x="18" y="219" xml:space="preserve"><tspan fill="#D4D4D4">    </tspan><tspan fill="#9CDCFE">s</tspan><tspan fill="#D4D4D4"> := </tspan><tspan fill="#B5CEA8">0</tspan></text>
+  <text x="18" y="240" xml:space="preserve"><tspan fill="#D4D4D4">  </tspan><tspan fill="#C586C0">else</tspan></text>
+  <text x="18" y="261" xml:space="preserve"><tspan fill="#D4D4D4">    </tspan><tspan fill="#569CD6">sum_to</tspan><tspan fill="#D4D4D4">(</tspan><tspan fill="#9CDCFE">n</tspan><tspan fill="#D4D4D4"> - </tspan><tspan fill="#B5CEA8">1</tspan><tspan fill="#D4D4D4">);  </tspan><tspan fill="#6A9955">// 2 * s = (n - 1) * n</tspan></text>
+  <text x="18" y="282" xml:space="preserve"><tspan fill="#D4D4D4">    </tspan><tspan fill="#9CDCFE">s</tspan><tspan fill="#D4D4D4"> := </tspan><tspan fill="#9CDCFE">s</tspan><tspan fill="#D4D4D4"> + </tspan><tspan fill="#9CDCFE">n</tspan><tspan fill="#D4D4D4">      </tspan><tspan fill="#6A9955">// 2 * s = n * (n + 1)</tspan></text>
+  <text x="18" y="303" xml:space="preserve"><tspan fill="#D4D4D4">  </tspan><tspan fill="#C586C0">end</tspan></text>
+  <text x="18" y="324" xml:space="preserve"><tspan fill="#C586C0">end</tspan></text>
+  <text x="18" y="345" xml:space="preserve"></text>
+  <text x="18" y="366" xml:space="preserve"><tspan fill="#D4D4D4">{ </tspan><tspan fill="#569CD6">true</tspan><tspan fill="#D4D4D4"> }</tspan></text>
+  <text x="18" y="387" xml:space="preserve"><tspan fill="#569CD6">sum_to</tspan><tspan fill="#D4D4D4">(</tspan><tspan fill="#B5CEA8">5</tspan><tspan fill="#D4D4D4">)</tspan></text>
+  <text x="18" y="408" xml:space="preserve"><tspan fill="#D4D4D4">{ </tspan><tspan fill="#B5CEA8">2</tspan><tspan fill="#D4D4D4"> * </tspan><tspan fill="#9CDCFE">s</tspan><tspan fill="#D4D4D4"> = </tspan><tspan fill="#B5CEA8">30</tspan><tspan fill="#D4D4D4"> }  </tspan><tspan fill="#6A9955">// 1 + 2 + 3 + 4 + 5 = 15</tspan></text>
 </svg>

--- a/assets/snippet-recursive-procedure-light.svg
+++ b/assets/snippet-recursive-procedure-light.svg
@@ -1,21 +1,22 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="696" height="410" viewBox="0 0 696 410" font-family='ui-monospace, "SF Mono", Menlo, Consolas, monospace' font-size="14">
+<svg xmlns="http://www.w3.org/2000/svg" width="722" height="431" viewBox="0 0 722 431" font-family='ui-monospace, "SF Mono", Menlo, Consolas, monospace' font-size="14">
   <rect width="100%" height="100%" fill="#FFFFFF" rx="10"/>
-  <text x="18" y="30" xml:space="preserve"><tspan fill="#008000">// A procedure may call itself. The `variant` strictly decreases across each</tspan></text>
-  <text x="18" y="51" xml:space="preserve"><tspan fill="#008000">// recursive call, which is what proves the recursion terminates.</tspan></text>
-  <text x="18" y="72" xml:space="preserve"><tspan fill="#AF00DB">procedure</tspan><tspan fill="#000000"> </tspan><tspan fill="#569CD6">sum_to</tspan><tspan fill="#000000"> (</tspan><tspan fill="#001080">n</tspan><tspan fill="#000000">) =</tspan></text>
-  <text x="18" y="93" xml:space="preserve"><tspan fill="#000000">  </tspan><tspan fill="#0000FF" font-style="italic">requires</tspan><tspan fill="#000000"> { </tspan><tspan fill="#001080">n</tspan><tspan fill="#000000"> &gt;= </tspan><tspan fill="#098658">0</tspan><tspan fill="#000000"> }</tspan></text>
-  <text x="18" y="114" xml:space="preserve"><tspan fill="#000000">  </tspan><tspan fill="#0000FF" font-style="italic">ensures</tspan><tspan fill="#000000"> { </tspan><tspan fill="#001080">s</tspan><tspan fill="#000000"> &gt;= </tspan><tspan fill="#098658">0</tspan><tspan fill="#000000"> }</tspan></text>
-  <text x="18" y="135" xml:space="preserve"><tspan fill="#000000">  </tspan><tspan fill="#0000FF" font-style="italic">variant</tspan><tspan fill="#000000"> { </tspan><tspan fill="#001080">n</tspan><tspan fill="#000000"> }</tspan></text>
-  <text x="18" y="156" xml:space="preserve"><tspan fill="#000000">  </tspan><tspan fill="#0000FF" font-style="italic">writes</tspan><tspan fill="#000000"> { </tspan><tspan fill="#001080">s</tspan><tspan fill="#000000"> }</tspan></text>
-  <text x="18" y="177" xml:space="preserve"><tspan fill="#000000">  </tspan><tspan fill="#AF00DB">if</tspan><tspan fill="#000000"> </tspan><tspan fill="#001080">n</tspan><tspan fill="#000000"> = </tspan><tspan fill="#098658">0</tspan><tspan fill="#000000"> </tspan><tspan fill="#AF00DB">then</tspan></text>
-  <text x="18" y="198" xml:space="preserve"><tspan fill="#000000">    </tspan><tspan fill="#001080">s</tspan><tspan fill="#000000"> := </tspan><tspan fill="#098658">0</tspan></text>
-  <text x="18" y="219" xml:space="preserve"><tspan fill="#000000">  </tspan><tspan fill="#AF00DB">else</tspan></text>
-  <text x="18" y="240" xml:space="preserve"><tspan fill="#000000">    </tspan><tspan fill="#569CD6">sum_to</tspan><tspan fill="#000000">(</tspan><tspan fill="#001080">n</tspan><tspan fill="#000000"> - </tspan><tspan fill="#098658">1</tspan><tspan fill="#000000">);</tspan></text>
-  <text x="18" y="261" xml:space="preserve"><tspan fill="#000000">    </tspan><tspan fill="#001080">s</tspan><tspan fill="#000000"> := </tspan><tspan fill="#001080">s</tspan><tspan fill="#000000"> + </tspan><tspan fill="#001080">n</tspan></text>
-  <text x="18" y="282" xml:space="preserve"><tspan fill="#000000">  </tspan><tspan fill="#AF00DB">end</tspan></text>
-  <text x="18" y="303" xml:space="preserve"><tspan fill="#AF00DB">end</tspan></text>
-  <text x="18" y="324" xml:space="preserve"></text>
-  <text x="18" y="345" xml:space="preserve"><tspan fill="#000000">{ </tspan><tspan fill="#0000FF">true</tspan><tspan fill="#000000"> }</tspan></text>
-  <text x="18" y="366" xml:space="preserve"><tspan fill="#569CD6">sum_to</tspan><tspan fill="#000000">(</tspan><tspan fill="#098658">5</tspan><tspan fill="#000000">)</tspan></text>
-  <text x="18" y="387" xml:space="preserve"><tspan fill="#000000">{ </tspan><tspan fill="#001080">s</tspan><tspan fill="#000000"> &gt;= </tspan><tspan fill="#098658">0</tspan><tspan fill="#000000"> }</tspan></text>
+  <text x="18" y="30" xml:space="preserve"><tspan fill="#008000">// A procedure may call itself. Its contract carries across the recursive call:</tspan></text>
+  <text x="18" y="51" xml:space="preserve"><tspan fill="#008000">// the `ensures` proved for `sum_to(n - 1)` is what the body reasons from, and</tspan></text>
+  <text x="18" y="72" xml:space="preserve"><tspan fill="#008000">// the `variant` — strictly decreasing at each call — proves it terminates.</tspan></text>
+  <text x="18" y="93" xml:space="preserve"><tspan fill="#AF00DB">procedure</tspan><tspan fill="#000000"> </tspan><tspan fill="#569CD6">sum_to</tspan><tspan fill="#000000"> (</tspan><tspan fill="#001080">n</tspan><tspan fill="#000000">) =</tspan></text>
+  <text x="18" y="114" xml:space="preserve"><tspan fill="#000000">  </tspan><tspan fill="#0000FF" font-style="italic">requires</tspan><tspan fill="#000000"> { </tspan><tspan fill="#001080">n</tspan><tspan fill="#000000"> &gt;= </tspan><tspan fill="#098658">0</tspan><tspan fill="#000000"> }</tspan></text>
+  <text x="18" y="135" xml:space="preserve"><tspan fill="#000000">  </tspan><tspan fill="#0000FF" font-style="italic">ensures</tspan><tspan fill="#000000"> { </tspan><tspan fill="#098658">2</tspan><tspan fill="#000000"> * </tspan><tspan fill="#001080">s</tspan><tspan fill="#000000"> = </tspan><tspan fill="#001080">n</tspan><tspan fill="#000000"> * (</tspan><tspan fill="#001080">n</tspan><tspan fill="#000000"> + </tspan><tspan fill="#098658">1</tspan><tspan fill="#000000">) }</tspan></text>
+  <text x="18" y="156" xml:space="preserve"><tspan fill="#000000">  </tspan><tspan fill="#0000FF" font-style="italic">variant</tspan><tspan fill="#000000"> { </tspan><tspan fill="#001080">n</tspan><tspan fill="#000000"> }</tspan></text>
+  <text x="18" y="177" xml:space="preserve"><tspan fill="#000000">  </tspan><tspan fill="#0000FF" font-style="italic">writes</tspan><tspan fill="#000000"> { </tspan><tspan fill="#001080">s</tspan><tspan fill="#000000"> }</tspan></text>
+  <text x="18" y="198" xml:space="preserve"><tspan fill="#000000">  </tspan><tspan fill="#AF00DB">if</tspan><tspan fill="#000000"> </tspan><tspan fill="#001080">n</tspan><tspan fill="#000000"> = </tspan><tspan fill="#098658">0</tspan><tspan fill="#000000"> </tspan><tspan fill="#AF00DB">then</tspan></text>
+  <text x="18" y="219" xml:space="preserve"><tspan fill="#000000">    </tspan><tspan fill="#001080">s</tspan><tspan fill="#000000"> := </tspan><tspan fill="#098658">0</tspan></text>
+  <text x="18" y="240" xml:space="preserve"><tspan fill="#000000">  </tspan><tspan fill="#AF00DB">else</tspan></text>
+  <text x="18" y="261" xml:space="preserve"><tspan fill="#000000">    </tspan><tspan fill="#569CD6">sum_to</tspan><tspan fill="#000000">(</tspan><tspan fill="#001080">n</tspan><tspan fill="#000000"> - </tspan><tspan fill="#098658">1</tspan><tspan fill="#000000">);  </tspan><tspan fill="#008000">// 2 * s = (n - 1) * n</tspan></text>
+  <text x="18" y="282" xml:space="preserve"><tspan fill="#000000">    </tspan><tspan fill="#001080">s</tspan><tspan fill="#000000"> := </tspan><tspan fill="#001080">s</tspan><tspan fill="#000000"> + </tspan><tspan fill="#001080">n</tspan><tspan fill="#000000">      </tspan><tspan fill="#008000">// 2 * s = n * (n + 1)</tspan></text>
+  <text x="18" y="303" xml:space="preserve"><tspan fill="#000000">  </tspan><tspan fill="#AF00DB">end</tspan></text>
+  <text x="18" y="324" xml:space="preserve"><tspan fill="#AF00DB">end</tspan></text>
+  <text x="18" y="345" xml:space="preserve"></text>
+  <text x="18" y="366" xml:space="preserve"><tspan fill="#000000">{ </tspan><tspan fill="#0000FF">true</tspan><tspan fill="#000000"> }</tspan></text>
+  <text x="18" y="387" xml:space="preserve"><tspan fill="#569CD6">sum_to</tspan><tspan fill="#000000">(</tspan><tspan fill="#098658">5</tspan><tspan fill="#000000">)</tspan></text>
+  <text x="18" y="408" xml:space="preserve"><tspan fill="#000000">{ </tspan><tspan fill="#098658">2</tspan><tspan fill="#000000"> * </tspan><tspan fill="#001080">s</tspan><tspan fill="#000000"> = </tspan><tspan fill="#098658">30</tspan><tspan fill="#000000"> }  </tspan><tspan fill="#008000">// 1 + 2 + 3 + 4 + 5 = 15</tspan></text>
 </svg>


### PR DESCRIPTION
## Summary

Rewrites the README's front-page examples down to two, per the request to keep only the triangle-numbers example plus one showing procedures and contracts with recursion.

- **Computing triangle numbers** — unchanged (loops, `invariant`/`variant`).
- **Procedures, contracts, and recursion** — a recursive `sum_to` procedure that sums `1 + 2 + … + n`.

The straight-line Hoare-triple and Euclidean-division examples are dropped from the front page but remain in the [`EXAMPLES.md`](assets/readme-snippets/EXAMPLES.md) gallery.

## Details

- Strengthened `recursive-procedure.cav`'s contract from the weak `ensures { s >= 0 }` to the exact `ensures { 2 * s = n * (n + 1) }`, so it demonstrates a meaningful postcondition carried across the recursive call. Kept the integer-friendly `2*s = …` phrasing (matching the triangle example) to avoid division in the proof.
- Updated the Examples intro prose and moved the front-page ★ in `EXAMPLES.md` (off Hoare-triple and Euclidean-division, onto Recursion — now "two marked ★").
- Regenerated the light/dark snippet SVGs.

## Verification

- `dune exec -- cav verify` passes for the recursive-procedure, triangle-numbers, and euclidean-division snippets.
- `npm run check` reports the snippets up to date.